### PR TITLE
🧹 tf lint

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,59 @@
+config {
+  disabled_by_default = false
+}
+
+plugin "terraform" {
+  enabled = true
+}
+
+rule "terraform_comment_syntax" {
+  enabled = true
+}
+
+rule "terraform_deprecated_index" {
+  enabled = true
+}
+
+rule "terraform_deprecated_interpolation" {
+  enabled = true
+}
+
+rule "terraform_deprecated_lookup" {
+  enabled = true
+}
+
+rule "terraform_empty_list_equality" {
+  enabled = true
+}
+
+rule "terraform_module_pinned_source" {
+  enabled = true
+}
+
+rule "terraform_module_version" {
+  enabled = true
+}
+
+rule "terraform_required_providers" {
+  enabled = true
+}
+
+rule "terraform_typed_variables" {
+  enabled = true
+}
+
+rule "terraform_unused_declarations" {
+  enabled = true
+}
+
+rule "terraform_workspace_remote" {
+  enabled = true
+}
+
+rule "terraform_required_version" {
+  enabled = false
+}
+
+rule "terraform_standard_module_structure" {
+  enabled = false
+}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,6 +23,12 @@ fmt:
 test:
 	go test -v -cover -timeout=120s -parallel=4 ./...
 
+hcl/fmt:
+	terraform fmt -recursive
+
+hcl/lint:
+	tflint --recursive --config $(PWD)/.tflint.hcl
+
 # Run acceptance tests
 testacc:
 	TF_ACC=1 go test ./... -v $(TESTARGS) -timeout 120m

--- a/docs/data-sources/organization.md
+++ b/docs/data-sources/organization.md
@@ -13,23 +13,15 @@ Organization data source
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
-provider "mondoo" {
-}
+provider "mondoo" {}
 
 data "mondoo_organization" "org" {
   id = "reverent-ride-275852"
 }
 
 output "org_mrn" {
-  value = data.mondoo_organization.org.mrn
+  description = "MRN of the organization"
+  value       = data.mondoo_organization.org.mrn
 }
 ```
 

--- a/docs/data-sources/space.md
+++ b/docs/data-sources/space.md
@@ -13,23 +13,15 @@ Space data source
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
+variable "mondoo_org" {
+  description = "Mondoo Organization"
+  type        = string
 }
 
-provider "mondoo" {
-}
-
-data "mondoo_organization" "org" {
-  id = "reverent-ride-275852"
-}
+provider "mondoo" {}
 
 resource "mondoo_space" "test" {
-  org_id = mondoo_organization.org.id
+  org_id = var.mondoo_org.value
   name   = "test-space"
 }
 
@@ -42,7 +34,13 @@ data "mondoo_space" "space" {
 }
 
 output "space_name" {
-  value = data.mondoo_space.name
+  description = "The name of the space"
+  value       = data.mondoo_space.space.name
+}
+
+output "space_mrn" {
+  description = "The MRN of the space"
+  value       = data.mondoo_space.space.mrn
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,8 @@ The Mondoo provider is used to configure your Mondoo Platform infrastructure.
 terraform {
   required_providers {
     mondoo = {
-      source = "mondoohq/mondoo"
+      source  = "mondoohq/mondoo"
+      version = ">= 0.4.0"
     }
   }
 }

--- a/docs/resources/custom_policy.md
+++ b/docs/resources/custom_policy.md
@@ -13,17 +13,7 @@ Custom Policy resource
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
-provider "mondoo" {
-
-}
+provider "mondoo" {}
 
 resource "mondoo_space" "my_space" {
   name   = "My Custom Space"
@@ -31,8 +21,9 @@ resource "mondoo_space" "my_space" {
 }
 
 variable "my_custom_policy" {
-  type    = string
-  default = "policy.mql.yaml"
+  description = "Path to the custom policy file. The file must be in MQL format."
+  type        = string
+  default     = "policy.mql.yaml"
 }
 
 resource "mondoo_custom_policy" "my_policy" {

--- a/docs/resources/custom_querypack.md
+++ b/docs/resources/custom_querypack.md
@@ -13,14 +13,6 @@ Custom Query Pack resource
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
 provider "mondoo" {
   region = "us"
 }
@@ -36,8 +28,9 @@ resource "mondoo_space" "my_space" {
 }
 
 variable "my_custom_querypack" {
-  type    = string
-  default = "querypack.mql.yaml"
+  description = "Path to custom querypack file. File must be in MQL format."
+  type        = string
+  default     = "querypack.mql.yaml"
 }
 
 resource "mondoo_custom_querypack" "my_query_pack" {

--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -13,23 +13,11 @@ Continuously scan Microsoft Azure subscriptions and resources for misconfigurati
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "2.48.0"
-    }
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
 provider "azuread" {}
 
 data "azuread_client_config" "current" {}
 
-data "azuread_application" "mondoo-security" {
+data "azuread_application" "mondoo_security" {
   display_name = "mondoo-security"
 }
 
@@ -42,18 +30,18 @@ variable "mondoo_org" {
   type        = string
 }
 
-// Create a new space
+# Create a new space
 resource "mondoo_space" "azure_space" {
-  name   = "Azure ${data.azuread_application.mondoo-security.display_name}"
+  name   = "Azure ${data.azuread_application.mondoo_security.display_name}"
   org_id = var.mondoo_org
 }
 
-// Setup the Azure integration
+# Setup the Azure integration
 resource "mondoo_integration_azure" "azure_integration" {
   space_id  = mondoo_space.azure_space.id
-  name      = "Azure ${data.azuread_application.mondoo-security.display_name}"
+  name      = "Azure ${data.azuread_application.mondoo_security.display_name}"
   tenant_id = data.azuread_client_config.current.tenant_id
-  client_id = data.azuread_application.mondoo-security.client_id
+  client_id = data.azuread_application.mondoo_security.client_id
   scan_vms  = true
   # subscription_allow_list= ["ffffffff-ffff-ffff-ffff-ffffffffffff", "ffffffff-ffff-ffff-ffff-ffffffffffff"]
   # subscription_deny_list = ["ffffffff-ffff-ffff-ffff-ffffffffffff", "ffffffff-ffff-ffff-ffff-ffffffffffff"]

--- a/docs/resources/integration_domain.md
+++ b/docs/resources/integration_domain.md
@@ -13,28 +13,25 @@ Continuously scan endpoints to evaluate domain TLS, SSL, HTTP, and HTTPS securit
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
+variable "mondoo_org" {
+  description = "The Mondoo Organization ID"
+  type        = string
 }
 
 provider "mondoo" {
   region = "us"
 }
 
-// Create a new space
+# Create a new space
 resource "mondoo_space" "domain_space" {
   name   = "My Space Name"
-  org_id = "your-org-1234567"
+  org_id = var.mondoo_org
 }
 
-// Setup the Domain integration
+# Setup the Domain integration
 resource "mondoo_integration_domain" "domain_integration" {
   space_id = mondoo_space.domain_space.id
-  host     = "example.com"
+  host     = "mondoo.com"
   https    = true
   http     = false
 }

--- a/docs/resources/integration_gcp.md
+++ b/docs/resources/integration_gcp.md
@@ -13,34 +13,37 @@ Continuously scan Google GCP organizations and projects for misconfigurations an
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
-provider "google" {
-  project = var.gcp_project
-  region  = "us-central1"
-}
+# Variables
+# ----------------------------------------------
 
 variable "gcp_project" {
   description = "GCP Project"
   type        = string
 }
 
+variable "mondoo_org" {
+  description = "Mondoo Organization"
+  type        = string
+}
+
+# Create GCP Service Account
+# ----------------------------------------------
+
+provider "google" {
+  project = var.gcp_project
+  region  = "us-central1"
+}
+
 data "google_project" "project" {}
 
-// Create a new service account
-// https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account_key
+# Create a new service account
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account_key
 resource "google_service_account" "mondoo_integration" {
   account_id   = "mondoo-integration"
   display_name = "My Service Account"
 }
 
-// Create a new service account key for the service account
+# Create a new service account key for the service account
 resource "google_service_account_key" "mykey" {
   service_account_id = google_service_account.mondoo_integration.name
 }
@@ -53,22 +56,20 @@ output "google_service_account_key" {
   sensitive   = true
 }
 
+# Configure the Mondoo
+# ----------------------------------------------
+
 provider "mondoo" {
   region = "us"
 }
 
-variable "mondoo_org" {
-  description = "Mondoo Organization"
-  type        = string
-}
-
-// Create a new space
+# Create a new space
 resource "mondoo_space" "my_space" {
   name   = "GCP ${data.google_project.project.name}"
   org_id = var.mondoo_org
 }
 
-// Setup the GCP integration
+# Setup the GCP integration
 resource "mondoo_integration_gcp" "name" {
   space_id   = mondoo_space.my_space.id
   name       = "GCP ${data.google_project.project.name}"

--- a/docs/resources/integration_oci_tenant.md
+++ b/docs/resources/integration_oci_tenant.md
@@ -13,24 +13,28 @@ Example resource
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
+# Variables
+# ----------------------------------------------
+
+variable "mondoo_org" {
+  description = "The Mondoo Organization ID"
+  type        = string
+  default     = "your-org-1234567"
 }
+
+# Configure the Mondoo
+# ----------------------------------------------
 
 provider "mondoo" {
   region = "us"
 }
 
 resource "mondoo_space" "my_space" {
-  name = "My Space Name"
-  # space_id = "your-space-id" # optional
-  org_id = "your-org-1234567"
+  name   = "My Space Name"
+  org_id = var.mondoo_org
 }
 
+# Setup the OCI integration
 resource "mondoo_integration_oci_tenant" "tenant_abc" {
   space_id = mondoo_space.my_space.id
   name     = "tenant ABC"

--- a/docs/resources/policy_assignment.md
+++ b/docs/resources/policy_assignment.md
@@ -13,14 +13,6 @@ description: |-
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
 provider "mondoo" {
   region = "us"
 }

--- a/docs/resources/querypack_assignment.md
+++ b/docs/resources/querypack_assignment.md
@@ -13,14 +13,6 @@ description: |-
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
 provider "mondoo" {
   region = "us"
 }

--- a/docs/resources/registration_token.md
+++ b/docs/resources/registration_token.md
@@ -11,15 +11,8 @@ Registration Token resource
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
-provider "mondoo" {}
+# Variables
+# ----------------------------------------------
 
 variable "space_names" {
   description = "Create Spaces with these names"
@@ -33,6 +26,13 @@ variable "org_id" {
   default     = ""
 }
 
+# Configure the Mondoo
+# ----------------------------------------------
+
+provider "mondoo" {
+  region = "us"
+}
+
 resource "mondoo_space" "my_space" {
   count  = length(var.space_names)
   name   = var.space_names[count.index]
@@ -44,13 +44,15 @@ resource "mondoo_registration_token" "token" {
   count         = length(var.space_names)
   space_id      = mondoo_space.my_space[count.index].id
   no_exipration = true
-  // expires_in = "1h"
+  # define optional expiration
+  # expires_in = "1h"
   depends_on = [
     mondoo_space.my_space
   ]
 }
 
-output "complete_space_setup" {
+output "space_registration_token" {
+  description = "The list of space registration tokens for the specified spaces"
   value = [
     for count, space in mondoo_space.my_space :
     {

--- a/docs/resources/scim_group_mapping.md
+++ b/docs/resources/scim_group_mapping.md
@@ -13,16 +13,7 @@ This resource provides SCIM 2.0 Group Mapping. It allows the mapping of SCIM 2.0
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
-provider "mondoo" {
-}
+provider "mondoo" {}
 
 data "mondoo_organization" "org" {
   id = "reverent-ride-275852"
@@ -33,7 +24,7 @@ resource "mondoo_space" "my_space_1" {
   org_id = data.mondoo_organization.org.id
 }
 
-resource "mondoo_scim_group_mapping" "MondooAdmin" {
+resource "mondoo_scim_group_mapping" "mondoo_admin" {
   org_id = data.mondoo_organization.org.id
   group  = "MondooAdmin"
   mappings = [
@@ -55,7 +46,8 @@ resource "mondoo_scim_group_mapping" "MondooAdmin" {
 }
 
 output "org_mrn" {
-  value = data.mondoo_organization.org.mrn
+  description = "The MRN of the organization"
+  value       = data.mondoo_organization.org.mrn
 }
 ```
 

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -13,29 +13,31 @@ Allows management of a Mondoo service account.
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
+# Variables
+# ----------------------------------------------
+
+variable "mondoo_org" {
+  description = "The Mondoo Organization ID"
+  type        = string
 }
+
+# Configure the Mondoo
+# ----------------------------------------------
 
 provider "mondoo" {
   region = "us"
 }
 
 resource "mondoo_space" "my_space" {
-  name = "My Space Name"
-  # space_id = "your-space-id" # optional
-  org_id = "your-org-1234567"
+  name   = "My Space Name"
+  org_id = var.mondoo_org
 }
 
 resource "mondoo_service_account" "service_account" {
   name        = "Service Account Terraform New"
   description = "Service Account for Terraform"
   roles = [
-    "//iam.api.mondoo.app/roles/viewer", // TODO use "roles/viewer"
+    "//iam.api.mondoo.app/roles/viewer",
   ]
   space_id = mondoo_space.my_space.id
 

--- a/docs/resources/space.md
+++ b/docs/resources/space.md
@@ -13,21 +13,14 @@ Space resource
 ## Example Usage
 
 ```terraform
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
 provider "mondoo" {
   region = "us"
 }
 
 resource "mondoo_space" "my_space" {
   name = "My Space New"
-  // id = "your-space-id" # optional otherwise it will be auto-generated
+  # optional id otherwise it will be auto-generated
+  # id = "your-space-id"
   org_id = "your-org-1234567"
 }
 ```

--- a/examples/data-sources/mondoo_organization/data-source.tf
+++ b/examples/data-sources/mondoo_organization/data-source.tf
@@ -1,18 +1,10 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
-provider "mondoo" {
-}
+provider "mondoo" {}
 
 data "mondoo_organization" "org" {
   id = "reverent-ride-275852"
 }
 
 output "org_mrn" {
-  value = data.mondoo_organization.org.mrn
+  description = "MRN of the organization"
+  value       = data.mondoo_organization.org.mrn
 }

--- a/examples/data-sources/mondoo_organization/main.tf
+++ b/examples/data-sources/mondoo_organization/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/data-sources/mondoo_space/data-source.tf
+++ b/examples/data-sources/mondoo_space/data-source.tf
@@ -1,20 +1,12 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
+variable "mondoo_org" {
+  description = "Mondoo Organization"
+  type        = string
 }
 
-provider "mondoo" {
-}
-
-data "mondoo_organization" "org" {
-  id = "reverent-ride-275852"
-}
+provider "mondoo" {}
 
 resource "mondoo_space" "test" {
-  org_id = mondoo_organization.org.id
+  org_id = var.mondoo_org.value
   name   = "test-space"
 }
 
@@ -27,5 +19,11 @@ data "mondoo_space" "space" {
 }
 
 output "space_name" {
-  value = data.mondoo_space.name
+  description = "The name of the space"
+  value       = data.mondoo_space.space.name
+}
+
+output "space_mrn" {
+  description = "The MRN of the space"
+  value       = data.mondoo_space.space.mrn
 }

--- a/examples/data-sources/mondoo_space/main.tf
+++ b/examples/data-sources/mondoo_space/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/.gitignore
+++ b/examples/resources/.gitignore
@@ -1,0 +1,1 @@
+**/terraform.tfvars

--- a/examples/resources/mondoo_custom_policy/main.tf
+++ b/examples/resources/mondoo_custom_policy/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/mondoo_custom_policy/resource.tf
+++ b/examples/resources/mondoo_custom_policy/resource.tf
@@ -1,14 +1,4 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
-provider "mondoo" {
-
-}
+provider "mondoo" {}
 
 resource "mondoo_space" "my_space" {
   name   = "My Custom Space"
@@ -16,8 +6,9 @@ resource "mondoo_space" "my_space" {
 }
 
 variable "my_custom_policy" {
-  type    = string
-  default = "policy.mql.yaml"
+  description = "Path to the custom policy file. The file must be in MQL format."
+  type        = string
+  default     = "policy.mql.yaml"
 }
 
 resource "mondoo_custom_policy" "my_policy" {

--- a/examples/resources/mondoo_custom_querypack/main.tf
+++ b/examples/resources/mondoo_custom_querypack/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/mondoo_custom_querypack/resource.tf
+++ b/examples/resources/mondoo_custom_querypack/resource.tf
@@ -1,11 +1,3 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
 provider "mondoo" {
   region = "us"
 }
@@ -21,8 +13,9 @@ resource "mondoo_space" "my_space" {
 }
 
 variable "my_custom_querypack" {
-  type    = string
-  default = "querypack.mql.yaml"
+  description = "Path to custom querypack file. File must be in MQL format."
+  type        = string
+  default     = "querypack.mql.yaml"
 }
 
 resource "mondoo_custom_querypack" "my_query_pack" {

--- a/examples/resources/mondoo_integration_azure/main.tf
+++ b/examples/resources/mondoo_integration_azure/main.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">= 2.48.0"
+    }
     mondoo = {
       source  = "mondoohq/mondoo"
       version = ">= 0.4.0"
     }
   }
-}
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
 }

--- a/examples/resources/mondoo_integration_azure/resource.tf
+++ b/examples/resources/mondoo_integration_azure/resource.tf
@@ -1,20 +1,8 @@
-terraform {
-  required_providers {
-    azuread = {
-      source  = "hashicorp/azuread"
-      version = "2.48.0"
-    }
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
 provider "azuread" {}
 
 data "azuread_client_config" "current" {}
 
-data "azuread_application" "mondoo-security" {
+data "azuread_application" "mondoo_security" {
   display_name = "mondoo-security"
 }
 
@@ -27,18 +15,18 @@ variable "mondoo_org" {
   type        = string
 }
 
-// Create a new space
+# Create a new space
 resource "mondoo_space" "azure_space" {
-  name   = "Azure ${data.azuread_application.mondoo-security.display_name}"
+  name   = "Azure ${data.azuread_application.mondoo_security.display_name}"
   org_id = var.mondoo_org
 }
 
-// Setup the Azure integration
+# Setup the Azure integration
 resource "mondoo_integration_azure" "azure_integration" {
   space_id  = mondoo_space.azure_space.id
-  name      = "Azure ${data.azuread_application.mondoo-security.display_name}"
+  name      = "Azure ${data.azuread_application.mondoo_security.display_name}"
   tenant_id = data.azuread_client_config.current.tenant_id
-  client_id = data.azuread_application.mondoo-security.client_id
+  client_id = data.azuread_application.mondoo_security.client_id
   scan_vms  = true
   # subscription_allow_list= ["ffffffff-ffff-ffff-ffff-ffffffffffff", "ffffffff-ffff-ffff-ffff-ffffffffffff"]
   # subscription_deny_list = ["ffffffff-ffff-ffff-ffff-ffffffffffff", "ffffffff-ffff-ffff-ffff-ffffffffffff"]

--- a/examples/resources/mondoo_integration_domain/main.tf
+++ b/examples/resources/mondoo_integration_domain/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/mondoo_integration_domain/resource.tf
+++ b/examples/resources/mondoo_integration_domain/resource.tf
@@ -1,25 +1,22 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
+variable "mondoo_org" {
+  description = "The Mondoo Organization ID"
+  type        = string
 }
 
 provider "mondoo" {
   region = "us"
 }
 
-// Create a new space
+# Create a new space
 resource "mondoo_space" "domain_space" {
   name   = "My Space Name"
-  org_id = "your-org-1234567"
+  org_id = var.mondoo_org
 }
 
-// Setup the Domain integration
+# Setup the Domain integration
 resource "mondoo_integration_domain" "domain_integration" {
   space_id = mondoo_space.domain_space.id
-  host     = "example.com"
+  host     = "mondoo.com"
   https    = true
   http     = false
 }

--- a/examples/resources/mondoo_integration_gcp/main.tf
+++ b/examples/resources/mondoo_integration_gcp/main.tf
@@ -4,9 +4,9 @@ terraform {
       source  = "mondoohq/mondoo"
       version = ">= 0.4.0"
     }
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.26.0"
+    }
   }
-}
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
 }

--- a/examples/resources/mondoo_integration_gcp/resource.tf
+++ b/examples/resources/mondoo_integration_gcp/resource.tf
@@ -1,31 +1,34 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
-provider "google" {
-  project = var.gcp_project
-  region  = "us-central1"
-}
+# Variables
+# ----------------------------------------------
 
 variable "gcp_project" {
   description = "GCP Project"
   type        = string
 }
 
+variable "mondoo_org" {
+  description = "Mondoo Organization"
+  type        = string
+}
+
+# Create GCP Service Account
+# ----------------------------------------------
+
+provider "google" {
+  project = var.gcp_project
+  region  = "us-central1"
+}
+
 data "google_project" "project" {}
 
-// Create a new service account
-// https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account_key
+# Create a new service account
+# https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account_key
 resource "google_service_account" "mondoo_integration" {
   account_id   = "mondoo-integration"
   display_name = "My Service Account"
 }
 
-// Create a new service account key for the service account
+# Create a new service account key for the service account
 resource "google_service_account_key" "mykey" {
   service_account_id = google_service_account.mondoo_integration.name
 }
@@ -38,22 +41,20 @@ output "google_service_account_key" {
   sensitive   = true
 }
 
+# Configure the Mondoo
+# ----------------------------------------------
+
 provider "mondoo" {
   region = "us"
 }
 
-variable "mondoo_org" {
-  description = "Mondoo Organization"
-  type        = string
-}
-
-// Create a new space
+# Create a new space
 resource "mondoo_space" "my_space" {
   name   = "GCP ${data.google_project.project.name}"
   org_id = var.mondoo_org
 }
 
-// Setup the GCP integration
+# Setup the GCP integration
 resource "mondoo_integration_gcp" "name" {
   space_id   = mondoo_space.my_space.id
   name       = "GCP ${data.google_project.project.name}"

--- a/examples/resources/mondoo_integration_oci_tenant/main.tf
+++ b/examples/resources/mondoo_integration_oci_tenant/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/mondoo_integration_oci_tenant/resource.tf
+++ b/examples/resources/mondoo_integration_oci_tenant/resource.tf
@@ -1,21 +1,25 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
+# Variables
+# ----------------------------------------------
+
+variable "mondoo_org" {
+  description = "The Mondoo Organization ID"
+  type        = string
+  default     = "your-org-1234567"
 }
+
+# Configure the Mondoo
+# ----------------------------------------------
 
 provider "mondoo" {
   region = "us"
 }
 
 resource "mondoo_space" "my_space" {
-  name = "My Space Name"
-  # space_id = "your-space-id" # optional
-  org_id = "your-org-1234567"
+  name   = "My Space Name"
+  org_id = var.mondoo_org
 }
 
+# Setup the OCI integration
 resource "mondoo_integration_oci_tenant" "tenant_abc" {
   space_id = mondoo_space.my_space.id
   name     = "tenant ABC"

--- a/examples/resources/mondoo_policy_assignment/main.tf
+++ b/examples/resources/mondoo_policy_assignment/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/mondoo_policy_assignment/resource.tf
+++ b/examples/resources/mondoo_policy_assignment/resource.tf
@@ -1,11 +1,3 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
 provider "mondoo" {
   region = "us"
 }

--- a/examples/resources/mondoo_querypack_assignment/main.tf
+++ b/examples/resources/mondoo_querypack_assignment/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/mondoo_querypack_assignment/resource.tf
+++ b/examples/resources/mondoo_querypack_assignment/resource.tf
@@ -1,11 +1,3 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
 provider "mondoo" {
   region = "us"
 }

--- a/examples/resources/mondoo_registration_token/main.tf
+++ b/examples/resources/mondoo_registration_token/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/mondoo_registration_token/resource.tf
+++ b/examples/resources/mondoo_registration_token/resource.tf
@@ -1,12 +1,5 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
-provider "mondoo" {}
+# Variables
+# ----------------------------------------------
 
 variable "space_names" {
   description = "Create Spaces with these names"
@@ -20,6 +13,13 @@ variable "org_id" {
   default     = ""
 }
 
+# Configure the Mondoo
+# ----------------------------------------------
+
+provider "mondoo" {
+  region = "us"
+}
+
 resource "mondoo_space" "my_space" {
   count  = length(var.space_names)
   name   = var.space_names[count.index]
@@ -31,13 +31,15 @@ resource "mondoo_registration_token" "token" {
   count         = length(var.space_names)
   space_id      = mondoo_space.my_space[count.index].id
   no_exipration = true
-  // expires_in = "1h"
+  # define optional expiration
+  # expires_in = "1h"
   depends_on = [
     mondoo_space.my_space
   ]
 }
 
-output "complete_space_setup" {
+output "space_registration_token" {
+  description = "The list of space registration tokens for the specified spaces"
   value = [
     for count, space in mondoo_space.my_space :
     {

--- a/examples/resources/mondoo_scim_group_mapping/main.tf
+++ b/examples/resources/mondoo_scim_group_mapping/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/mondoo_scim_group_mapping/resource.tf
+++ b/examples/resources/mondoo_scim_group_mapping/resource.tf
@@ -1,13 +1,4 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
-provider "mondoo" {
-}
+provider "mondoo" {}
 
 data "mondoo_organization" "org" {
   id = "reverent-ride-275852"
@@ -18,7 +9,7 @@ resource "mondoo_space" "my_space_1" {
   org_id = data.mondoo_organization.org.id
 }
 
-resource "mondoo_scim_group_mapping" "MondooAdmin" {
+resource "mondoo_scim_group_mapping" "mondoo_admin" {
   org_id = data.mondoo_organization.org.id
   group  = "MondooAdmin"
   mappings = [
@@ -40,5 +31,6 @@ resource "mondoo_scim_group_mapping" "MondooAdmin" {
 }
 
 output "org_mrn" {
-  value = data.mondoo_organization.org.mrn
+  description = "The MRN of the organization"
+  value       = data.mondoo_organization.org.mrn
 }

--- a/examples/resources/mondoo_service_account/main.tf
+++ b/examples/resources/mondoo_service_account/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/mondoo_service_account/resource.tf
+++ b/examples/resources/mondoo_service_account/resource.tf
@@ -1,26 +1,28 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
+# Variables
+# ----------------------------------------------
+
+variable "mondoo_org" {
+  description = "The Mondoo Organization ID"
+  type        = string
 }
+
+# Configure the Mondoo
+# ----------------------------------------------
 
 provider "mondoo" {
   region = "us"
 }
 
 resource "mondoo_space" "my_space" {
-  name = "My Space Name"
-  # space_id = "your-space-id" # optional
-  org_id = "your-org-1234567"
+  name   = "My Space Name"
+  org_id = var.mondoo_org
 }
 
 resource "mondoo_service_account" "service_account" {
   name        = "Service Account Terraform New"
   description = "Service Account for Terraform"
   roles = [
-    "//iam.api.mondoo.app/roles/viewer", // TODO use "roles/viewer"
+    "//iam.api.mondoo.app/roles/viewer",
   ]
   space_id = mondoo_space.my_space.id
 

--- a/examples/resources/mondoo_space/main.tf
+++ b/examples/resources/mondoo_space/main.tf
@@ -6,7 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {
-  region = "us" # use "eu" for the European region
-}

--- a/examples/resources/mondoo_space/resource.tf
+++ b/examples/resources/mondoo_space/resource.tf
@@ -1,18 +1,11 @@
-terraform {
-  required_providers {
-    mondoo = {
-      source = "mondoohq/mondoo"
-    }
-  }
-}
-
 provider "mondoo" {
   region = "us"
 }
 
 resource "mondoo_space" "my_space" {
   name = "My Space New"
-  // id = "your-space-id" # optional otherwise it will be auto-generated
+  # optional id otherwise it will be auto-generated
+  # id = "your-space-id"
   org_id = "your-org-1234567"
 }
 


### PR DESCRIPTION
This PR adds tflint and hcl formatting to the makefile. To ensure all examples are formatted correctly, run:

```
make hcl/fmt
```

We also added tflint to ensure that our examples meet best practices:

```
make hcl/lint
```

To meet the requirements we updated the examples. To keep the docs more focused on the resources, we also extracted the `required_providers` into `main.tf`. For most examples we also introduced a variable for the org id, which makes testing the examples easier because it allows to define a local `terraform.tfvars` to set the correct org.