### PR TITLE
🧹 update tested tf versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,13 +60,13 @@ jobs:
       fail-fast: false
       max-parallel: 2
       matrix:
-        # list whatever Terraform versions here you would like to support
+        # list Terraform versions we support, at least last 3 versions
         terraform:
           - '1.0.*'
-          - '1.1.*'
-          - '1.2.*'
           - '1.3.*'
-          - '1.4.*'
+          - '1.6.*'
+          - '1.7.*'
+          - '1.8.*'
     steps:
       - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
       - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0


### PR DESCRIPTION
Include terraform 1.8 and 1.7 in testing.