### PR TITLE
✨ enter/exit development mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 example.tf
 terraform.tfplan
 terraform.tfstate
+.terraform.lock.hcl
 bin/
 dist/
 modules-dev/

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,3 +1,6 @@
+PLUGINS_DIR="$(HOME)/.terraform.d/plugins"
+DEV_BIN_PATH="registry.terraform.io/mondoohq/mondoo/99.0.0/$$(go env GOOS)_$$(go env GOARCH)/terraform-provider-mondoo_v99.0.0"
+
 default: testacc
 
 default: build
@@ -9,24 +12,44 @@ install: build
 	go install -v ./...
 
 # See https://golangci-lint.run/
-lint:
+lint: ## Runs go linter
 	golangci-lint run
 
 # Generate docs and copywrite headers
-generate:
+generate: ## Generate or update documentation
 	cd tools; go generate .
 	go generate ./...
 
-fmt:
+fmt: ## Runs go formatter
 	gofmt -s -w -e .
 
-test:
+.PHONY: dev/enter
+dev/enter: write-terraform-rc ## Updates the terraformrc to point to the DEV_BIN_PATH. Installs the provider to the DEV_BIN_PATH
+	mkdir -vp $(PLUGINS_DIR)
+	go build -o $(PLUGINS_DIR)/$(DEV_BIN_PATH)
+
+.PHONY: dev/exit
+dev/exit: remove-terraform-rc ## Removes development provider package from DEV_BIN_PATH
+	@rm -rvf "$(PLUGINS_DIR)/$(DEV_BIN_PATH)"
+
+.PHONY: write-terraform-rc
+write-terraform-rc: ## Write to terraformrc file to mirror mondoohq/mondoo to DEV_BIN_PATH
+	scripts/mirror-provider.sh
+
+.PHONY: remove-terraform-rc
+remove-terraform-rc: ## Remove the terraformrc file
+	@rm -vf "$(HOME)/.terraformrc"
+
+help: ## Show this help
+	@grep -E '^([a-zA-Z_/-]+):.*## ' $(MAKEFILE_LIST) | awk -F ':.*## ' '{printf "%-20s %s\n", $$1, $$2}'
+
+test: ## Runs go tests
 	go test -v -cover -timeout=120s -parallel=4 ./...
 
-hcl/fmt:
+hcl/fmt: ## Runs terraform formatter
 	terraform fmt -recursive
 
-hcl/lint:
+hcl/lint: ## Runs terraform linter
 	tflint --recursive --config $(PWD)/.tflint.hcl
 
 # Run acceptance tests

--- a/README.md
+++ b/README.md
@@ -20,15 +20,25 @@ provider "mondoo" {
 }
 ```
 
+### Requirements
+
+If you wish to work on the provider, you'll need:
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.0
+- [Go](https://golang.org/doc/install) >= 1.21
+
 ## Developing the provider
 
-If you wish to work on the provider, you'll first need [Go](http://www.go.dev) installed on your machine (
-see [Requirements](#requirements) above).
+To enter development mode, run `make dev/enter`. This will build the provider inside the Terraform plugins directory
+and generate a Terraform configuration `~/.terraformrc`.
 
-To compile the provider, run `go install`. This will build the provider and put the provider binary in the `$GOPATH/bin`
-directory.
+Once in development mode, you can change directories to any of the Terraform plans in the [examples/](examples/) folder.
 
-To generate or update documentation, run `go generate`.
+To exit development mode, run `make dev/exit`. Note that this will remove the Terraform configuration `~/.terraformrc`.
+
+### Documentation and Test
+
+To generate or update documentation, run `make generate`.
 
 In order to run the full suite of Acceptance tests, run `make testacc`.
 
@@ -46,11 +56,6 @@ structure contains the following directories:
 - A resource and a data source (`internal/provider/`),
 - Examples (`examples/`) and generated documentation (`docs/`),
 - Miscellaneous meta files.
-
-### Requirements
-
-- [Terraform](https://developer.hashicorp.com/terraform/install) >= 1.0
-- [Go](https://golang.org/doc/install) >= 1.21
 
 ### Building The Provider
 

--- a/scripts/mirror-provider.sh
+++ b/scripts/mirror-provider.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# create a .terraformrc file only if the file is not present
+write_terraform_rc() {
+  if [[ -f "$HOME/.terraformrc" ]]; then
+    return 0
+  fi
+
+  cat > "$HOME/.terraformrc" << EOL
+provider_installation {
+    filesystem_mirror {
+        path    = "$HOME/.terraform.d/plugins"
+        include = ["mondoohq/mondoo"]
+    }
+    direct {
+        exclude = ["mondoohq/mondoo"]
+    }
+}
+EOL
+}
+
+write_terraform_rc "$@" || exit 99


### PR DESCRIPTION
This change adds easier Make directives to enter and exit development mode, where you can use any Terraform plan to test the built provider.

It also adds a `help` directive that looks like:
```
$ make help
lint                 Runs go linter
generate             Generate or update documentation
fmt                  Runs go formatter
dev/enter            Updates the terraformrc to point to the DEV_BIN_PATH. Installs the provider to the DEV_BIN_PATH
dev/exit             Removes development provider package from DEV_BIN_PATH
write-terraform-rc   Write to terraformrc file to mirror mondoohq/mondoo to DEV_BIN_PATH
remove-terraform-rc  Remove the terraformrc file
help                 Show this help
test                 Runs go tests
hcl/fmt              Runs terraform formatter
hcl/lint             Runs terraform linter
```