### PR TITLE
🐛 workspace: clean space_id from mrn

### DIFF
--- a/internal/provider/workspace_resource.go
+++ b/internal/provider/workspace_resource.go
@@ -484,7 +484,7 @@ func (r *WorkspaceResource) Create(ctx context.Context, req resource.CreateReque
 		"response": fmt.Sprintf("%+v", createMutation),
 	})
 	// Save space mrn into the Terraform state.
-	data.SpaceID = types.StringValue(createMutation.Workspace.OwnerMrn)
+	data.SpaceID = types.StringValue(SpaceFrom(createMutation.Workspace.OwnerMrn).ID())
 	data.Mrn = types.StringValue(createMutation.Workspace.Mrn)
 	data.Name = types.StringValue(createMutation.Workspace.Name)
 	data.Description = types.StringValue(createMutation.Workspace.Description)
@@ -518,7 +518,7 @@ func (r *WorkspaceResource) queryWorkspace(ctx context.Context, mrn string) (Wor
 	})
 
 	return WorkspaceResourceModel{
-		SpaceID:     types.StringValue(q.Workspace.OwnerMrn),
+		SpaceID:     types.StringValue(SpaceFrom(q.Workspace.OwnerMrn).ID()),
 		Mrn:         types.StringValue(q.Workspace.Mrn),
 		Name:        types.StringValue(q.Workspace.Name),
 		Description: types.StringValue(q.Workspace.Description),
@@ -602,7 +602,7 @@ func (r *WorkspaceResource) Update(ctx context.Context, req resource.UpdateReque
 		"response": fmt.Sprintf("%+v", createMutation),
 	})
 	// Save space mrn into the Terraform state.
-	data.SpaceID = types.StringValue(createMutation.Workspace.OwnerMrn)
+	data.SpaceID = types.StringValue(SpaceFrom(createMutation.Workspace.OwnerMrn).ID())
 	data.Mrn = types.StringValue(createMutation.Workspace.Mrn)
 	data.Name = types.StringValue(createMutation.Workspace.Name)
 	data.Description = types.StringValue(createMutation.Workspace.Description)

--- a/internal/provider/workspace_resource_test.go
+++ b/internal/provider/workspace_resource_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccWorkspaceResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccWorkspaceResourceConfig(accSpace.ID(), "my test workspace", "development"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_workspace.test", "name", "my test workspace"),
+					resource.TestCheckResourceAttr("mondoo_workspace.test", "space_id", accSpace.ID()),
+				),
+			},
+			{
+				Config: testAccWorkspaceResourceWithSpaceInProviderConfig(accSpace.ID(), "some workspace", "qa"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_workspace.test", "name", "some workspace"),
+					resource.TestCheckResourceAttr("mondoo_workspace.test", "space_id", accSpace.ID()),
+				),
+			},
+			// ImportState testing
+			// @afiune this doesn't work since most of our resources doesn't have the `id` attribute
+			// if we add it, instead of the `mrn` or as a copy, this import test will work
+			// {
+			// ResourceName:      "mondoo_workspace.test",
+			// ImportState:       true,
+			// ImportStateVerify: true,
+			// },
+			// Update and Read testing
+			{
+				Config: testAccWorkspaceResourceConfig(accSpace.ID(), "my updated workspace", "production"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_workspace.test", "name", "my updated workspace"),
+					resource.TestCheckResourceAttr("mondoo_workspace.test", "space_id", accSpace.ID()),
+				),
+			},
+			{
+				Config: testAccWorkspaceResourceWithSpaceInProviderConfig(accSpace.ID(), "updated workspace", "production"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_workspace.test", "name", "updated workspace"),
+					resource.TestCheckResourceAttr("mondoo_workspace.test", "space_id", accSpace.ID()),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccWorkspaceResourceConfig(spaceID, name, env string) string {
+	return fmt.Sprintf(`
+resource "mondoo_workspace" "test" {
+  space_id         = %[1]q
+  name             = %[2]q
+  asset_selections = [
+    {
+      conditions = [
+        {
+          operator = "AND"
+          key_value_condition = {
+            field    = "LABELS"
+            operator = "CONTAINS"
+            values = [
+              {
+                key   = "environment"
+                value = %[3]q
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+`, spaceID, name, env)
+}
+
+func testAccWorkspaceResourceWithSpaceInProviderConfig(spaceID, name, env string) string {
+	return fmt.Sprintf(`
+provider "mondoo" {
+  space = %[1]q
+}
+
+resource "mondoo_workspace" "test" {
+  name             = %[2]q
+  asset_selections = [
+    {
+      conditions = [
+        {
+          operator = "AND"
+          key_value_condition = {
+            field    = "LABELS"
+            operator = "CONTAINS"
+            values = [
+              {
+                key   = "environment"
+                value = %[3]q
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+`, spaceID, name, env)
+}


### PR DESCRIPTION
Fixes the issue where we do not clean the space mrn that the platform returns, we need only the space id

Errors are similar to:
```
  Error: Provider produced inconsistent result after apply
    When applying changes to mondoo_workspace.test, provider "provider[\"registry.terraform.io/mondoohq/mondoo\"]" produced an unexpected new value:
       .space_id: was │ cty.StringVal("angry-dubinsky-872643"), but now cty.StringVal("//captain.api.mondoo.app/spaces/angry-dubinsky-872643").

    This is a bug in the provider, which should be reported in the provider's own issue tracker.
```