### PR TITLE
🐛 Fix errors when handling unknown values

### DIFF
--- a/internal/provider/integration_aws_serverless_resource_test.go
+++ b/internal/provider/integration_aws_serverless_resource_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -80,10 +81,18 @@ func TestIntegrationAwsServerlessResourceValidateConfig_VPCFlavour(t *testing.T)
 		}
 
 		t.Run("with VpcTag", func(t *testing.T) {
-			d.ScanConfiguration.VpcConfiguration.VPCTag = VPCTagInput{
-				Key:   types.StringValue("Mondoo"),
-				Value: types.StringValue("true"),
-			}
+			vpcTag, diags := types.ObjectValue(
+				map[string]attr.Type{
+					"key":   types.StringType,
+					"value": types.StringType,
+				},
+				map[string]attr.Value{
+					"key":   types.StringValue("Mondoo"),
+					"value": types.StringValue("true"),
+				},
+			)
+			assert.False(t, diags.HasError())
+			d.ScanConfiguration.VpcConfiguration.VPCTag = vpcTag
 			diagnostics := validateIntegrationAwsServerlessResourceModel(d)
 			assert.False(t, diagnostics.HasError(), "expected NO errors")
 		})


### PR DESCRIPTION
This should fix the below error I am seeing when attempting to use the new vpc_tag field in serverless.

```
Error: Value Conversion Error
│ 
│   with mondoo_integration_aws_serverless.aws_serverless,
│   on main.tf line 317, in resource "mondoo_integration_aws_serverless" "aws_serverless":
│  317: resource "mondoo_integration_aws_serverless" "aws_serverless" {
│ 
│ An unexpected error was encountered trying to build a value. This is always
│ an error in the provider. Please report the following to the provider
│ developer:
│ 
│ Received null value, however the target type cannot handle null values. Use
│ the corresponding `types` package type, a pointer type or a custom type
│ that handles null values.
│ 
│ Path: scan_configuration.vpc_configuration.vpc_tag
│ Target Type: provider.VPCTagInput
│ Suggested `types` Type: basetypes.ObjectValue
│ Suggested Pointer Type: *provider.VPCTagInput
```