### PR TITLE
🐛 remove disabling of exceptions on creation

### DIFF
--- a/internal/provider/exception_resource.go
+++ b/internal/provider/exception_resource.go
@@ -268,14 +268,6 @@ func (r *exceptionResource) Create(ctx context.Context, req resource.CreateReque
 		return
 	}
 
-	// disable existing exceptions
-	tflog.Debug(ctx, fmt.Sprintf("Creating exception for scope %s", data.ScopeMrn.ValueString()))
-	err = r.client.ApplyException(ctx, scopeMrn, mondoov1.ExceptionMutationActionEnable, checks, []string{}, []string{}, vulnerabilities, (*string)(mondoov1.NewStringPtr("")), (*string)(mondoov1.NewStringPtr("")), (*bool)(mondoov1.NewBooleanPtr(false)))
-	if err != nil {
-		resp.Diagnostics.AddError("Failed to disable existing exception", err.Error())
-		return
-	}
-
 	// Create API call logic
 	tflog.Debug(ctx, fmt.Sprintf("Creating exception for scope %s", data.ScopeMrn.ValueString()))
 	err = r.client.ApplyException(ctx, scopeMrn, mondoov1.ExceptionMutationAction(data.Action.ValueString()), checks, []string{}, []string{}, vulnerabilities, data.Justification.ValueStringPointer(), &validUntilStr, (*bool)(mondoov1.NewBooleanPtr(false)))

--- a/internal/provider/exception_resource_test.go
+++ b/internal/provider/exception_resource_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccExceptionResource(t *testing.T) {
+	orgID, err := getOrgId()
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccExceptionResourceConfig(orgID, "A justification goes here"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_exception.test", "justification", "A justification goes here"),
+					resource.TestCheckResourceAttr("mondoo_exception.test", "action", "RISK_ACCEPTED"),
+				),
+			},
+			// ImportState testing
+			// NOTE: not implemented by resource
+			//
+			// Update and Read testing
+			{
+				Config: testAccExceptionResourceConfig(orgID, "A more complex justification"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_exception.test", "justification", "A more complex justification"),
+					resource.TestCheckResourceAttr("mondoo_exception.test", "action", "RISK_ACCEPTED"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccExceptionResourceConfig(resourceOrgID, justification string) string {
+	return fmt.Sprintf(`
+resource "mondoo_space" "test" {
+  org_id = %[1]q
+  name = "registration-token-test"
+}
+
+resource "mondoo_exception" "test" {
+  scope_mrn  = "//captain.api.mondoo.app/spaces/${mondoo_space.test.id}"
+  check_mrns = [
+    "//policy.api.mondoo.app/queries/mondoo-linux-security-permissions-on-ssh-private-host-key-files-are-configured"
+  ]
+  justification = %[2]q
+  action        = "RISK_ACCEPTED"
+  valid_until   = "2030-12-31"
+}
+`, resourceOrgID, justification)
+}


### PR DESCRIPTION
This resource is failing to apply with the error:
```
 ent: exception_group not found
```

Because we try to disable something that doesn't exist.