### PR TITLE
⭐️ auth: Workload Identity Federation (WIF)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
 	github.com/stretchr/testify v1.10.0
-	go.mondoo.com/cnquery/v11 v11.62.1
+	go.mondoo.com/cnquery/v11 v11.63.0
 	go.mondoo.com/mondoo-go v0.0.0-20250702005123-23558fe8001c
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
 	github.com/stretchr/testify v1.10.0
-	go.mondoo.com/cnquery/v11 v11.63.0
+	go.mondoo.com/cnquery/v11 v11.64.0
 	go.mondoo.com/mondoo-go v0.0.0-20250702005123-23558fe8001c
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -599,8 +599,8 @@ go.abhg.dev/goldmark/frontmatter v0.2.0/go.mod h1:XqrEkZuM57djk7zrlRUB02x8I5J0px
 go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=
 go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
-go.mondoo.com/cnquery/v11 v11.62.1 h1:D6A9yHTcTV2uCV+vCE1xvZJaotmSBBYNqBmxmZ6MGwo=
-go.mondoo.com/cnquery/v11 v11.62.1/go.mod h1:6rfarvzViSZsU+8N358cw2EF83tVPK7aUdF7Jj2DM1A=
+go.mondoo.com/cnquery/v11 v11.63.0 h1:weAO+kH+dz15A4YwQpPUYiwLXEm7qjzklM9s7TU59SY=
+go.mondoo.com/cnquery/v11 v11.63.0/go.mod h1:6rfarvzViSZsU+8N358cw2EF83tVPK7aUdF7Jj2DM1A=
 go.mondoo.com/mondoo-go v0.0.0-20250702005123-23558fe8001c h1:jiKGJYLW9rN6AOXicQmQSgVcZ+SZhM55NwPOfsBsUS8=
 go.mondoo.com/mondoo-go v0.0.0-20250702005123-23558fe8001c/go.mod h1:Ih8FsSC1VhLk7F3hS7Ji6nleAi29VMqRb7f555jr6SE=
 go.mondoo.com/ranger-rpc v0.7.0 h1:QZDgQ8y5e9sCS5BYjwaow1HWBfQ3UwIdfUEQ2SJRO58=

--- a/go.sum
+++ b/go.sum
@@ -601,6 +601,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
 go.mondoo.com/cnquery/v11 v11.63.0 h1:weAO+kH+dz15A4YwQpPUYiwLXEm7qjzklM9s7TU59SY=
 go.mondoo.com/cnquery/v11 v11.63.0/go.mod h1:6rfarvzViSZsU+8N358cw2EF83tVPK7aUdF7Jj2DM1A=
+go.mondoo.com/cnquery/v11 v11.64.0 h1:Z9vqcxng4tsqO3oJreLJmtVkWWlQUktOrPPQj5Ike/M=
+go.mondoo.com/cnquery/v11 v11.64.0/go.mod h1:6rfarvzViSZsU+8N358cw2EF83tVPK7aUdF7Jj2DM1A=
 go.mondoo.com/mondoo-go v0.0.0-20250702005123-23558fe8001c h1:jiKGJYLW9rN6AOXicQmQSgVcZ+SZhM55NwPOfsBsUS8=
 go.mondoo.com/mondoo-go v0.0.0-20250702005123-23558fe8001c/go.mod h1:Ih8FsSC1VhLk7F3hS7Ji6nleAi29VMqRb7f555jr6SE=
 go.mondoo.com/ranger-rpc v0.7.0 h1:QZDgQ8y5e9sCS5BYjwaow1HWBfQ3UwIdfUEQ2SJRO58=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"os"
 	"strings"
@@ -19,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	cnquery_config "go.mondoo.com/cnquery/v11/cli/config"
+	cnquery_upstream "go.mondoo.com/cnquery/v11/providers-sdk/v1/upstream"
 	mondoov1 "go.mondoo.com/mondoo-go"
 	"go.mondoo.com/mondoo-go/option"
 )
@@ -107,8 +109,18 @@ func (p *MondooProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		opts = append(opts, option.WithServiceAccount(data))
 		ctx = tflog.SetField(ctx, "env_config_base64", true)
 	} else if configPath != "" {
-		opts = append(opts, option.WithServiceAccountFile(configPath))
 		ctx = tflog.SetField(ctx, "env_config_path", true)
+		if cnquery_config.IsWifConfigFormat(configPath) {
+			ctx = tflog.SetField(ctx, "wif", true)
+			serviceAccount, err := serviceAccountFromWIF(configPath)
+			if err != nil {
+				resp.Diagnostics.AddError("Unable to exchange external token (WIF)", err.Error())
+				return
+			}
+			opts = append(opts, option.WithServiceAccount(serviceAccount))
+		} else {
+			opts = append(opts, option.WithServiceAccountFile(configPath))
+		}
 	} else if token != "" {
 		opts = append(opts, option.WithAPIToken(token))
 		ctx = tflog.SetField(ctx, "env_api_token", true)
@@ -116,6 +128,7 @@ func (p *MondooProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		opts = append(opts, option.WithServiceAccount([]byte(data.Credentials.ValueString())))
 		ctx = tflog.SetField(ctx, "field_credentials", true)
 	} else {
+		ctx = tflog.SetField(ctx, "default_cli_config_file", true)
 		// if no option was provided, try the default location of Mondoo CLI configuration file
 		defaultConfigPath, err := detectDefaultConfig()
 		if err != nil {
@@ -126,8 +139,17 @@ func (p *MondooProvider) Configure(ctx context.Context, req provider.ConfigureRe
 			)
 			return
 		}
-		opts = append(opts, option.WithServiceAccountFile(defaultConfigPath))
-		ctx = tflog.SetField(ctx, "default_cli_config_file", true)
+		if cnquery_config.IsWifConfigFormat(defaultConfigPath) {
+			ctx = tflog.SetField(ctx, "wif", true)
+			serviceAccount, err := serviceAccountFromWIF(defaultConfigPath)
+			if err != nil {
+				resp.Diagnostics.AddError("Unable to exchange external token (WIF)", err.Error())
+				return
+			}
+			opts = append(opts, option.WithServiceAccount(serviceAccount))
+		} else {
+			opts = append(opts, option.WithServiceAccountFile(defaultConfigPath))
+		}
 	}
 	tflog.Debug(ctx, "Detected authentication credentials")
 
@@ -236,4 +258,41 @@ func detectDefaultConfig() (string, error) {
 	}
 
 	return "", errors.New("no mondoo config found")
+}
+
+type wif struct {
+	UniverseDomain   string   `json:"universeDomain"`
+	Scopes           []string `json:"scopes"`
+	Type             string   `json:"type"`
+	Audience         string   `json:"audience"`
+	SubjectTokenType string   `json:"subjectTokenType"`
+	IssuerURI        string   `json:"issuerUri"`
+	JWTToken         string   `json:"jwtToken"`
+}
+
+func parseWIF(filename string) (*wif, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var w wif
+	err = json.Unmarshal(data, &w)
+	if err != nil {
+		return nil, err
+	}
+
+	return &w, nil
+}
+
+func serviceAccountFromWIF(filename string) ([]byte, error) {
+	wif, err := parseWIF(filename)
+	if err != nil {
+		return nil, err
+	}
+	svcAccount, err := cnquery_upstream.ExchangeExternalToken(wif.UniverseDomain, wif.Audience, wif.IssuerURI, wif.JWTToken)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(svcAccount)
 }


### PR DESCRIPTION
Depends on https://github.com/mondoohq/cnquery/pull/5636
### Summary

This change adds support for using Workload Identity Federation (WIF) as a credential source. It allows users to pass in a JWT token via environment variable or configuration file during the WIF exchange process.

### Motivation

In modern cloud-native environments, particularly when integrating with cloud providers (e.g., AWS, GCP, Azure), it is common to perform secure federated identity exchanges using JWTs issued by an OIDC-compliant identity provider.

#### Example Usage (Env + Config)

Use new environment variable:
```env
JWT_TOKEN=<your-jwt-token>
```


Plus the WIF configuration similar to:
```json
{
    "universeDomain": "https://api.edge.mondoo.com",
    "scopes": [
        "//iam.api.mondoo.app/roles/agent"
    ],
    "type": "external_account",
    "audience": "//captain.api.mondoo.app/spaces/epic-mclaren-654267",
    "subjectTokenType": "urn:ietf:params:oauth:token-type:jwt",
    "issuerUri": "https://accounts.google.com"
}
```

To test this you have to have a workload identity provider, in this case, for Google.

https://mondoo.com/docs/platform/maintain/access/non-human/wif/#which-wif-providers-does-mondoo-support

#### Example only config

If users are generating the WIF configuration on the fly, they can already inject the JWT token in it
rather than using the environment variable. This example shows how to generate a token and build
the configuration all at once.

```bash
echo '{
    "universeDomain": "https://api.edge.mondoo.com",
    "scopes": [
        "//iam.api.mondoo.app/roles/agent"
    ],
    "type": "external_account",
    "audience": "//captain.api.mondoo.app/spaces/epic-mclaren-654267",
    "subjectTokenType": "urn:ietf:params:oauth:token-type:jwt",
    "issuerUri": "https://accounts.google.com",
    "jwtToken": "'$(gcloud auth print-identity-token)'"
}' | jq . > /tmp/wif.json
```
**Note** that `jq` is used only for formatting purposes.
