### PR TITLE
🐛 SentinelOne host protocol validation

### DIFF
--- a/docs/resources/integration_sentinel_one.md
+++ b/docs/resources/integration_sentinel_one.md
@@ -26,7 +26,7 @@ provider "mondoo" {
 # Setup the SentinelOne integration
 resource "mondoo_integration_sentinel_one" "example" {
   name    = "SentinelOne Integration"
-  host    = "domain.sentinelone.net"
+  host    = "https://domain.sentinelone.net"
   account = "Your Account"
 
   credentials = {
@@ -42,7 +42,7 @@ resource "mondoo_integration_sentinel_one" "example" {
 
 - `account` (String) The account ID of the SentinelOne integration.
 - `credentials` (Attributes) Credentials require one of certificate or client secret to be provided. (see [below for nested schema](#nestedatt--credentials))
-- `host` (String) The host of the SentinelOne integration.
+- `host` (String) The host of the SentinelOne integration. Must include URL scheme, e.g., https://domain.sentinelone.net.
 - `name` (String) Name of the integration.
 
 ### Optional

--- a/examples/resources/mondoo_integration_sentinel_one/resource.tf
+++ b/examples/resources/mondoo_integration_sentinel_one/resource.tf
@@ -11,7 +11,7 @@ provider "mondoo" {
 # Setup the SentinelOne integration
 resource "mondoo_integration_sentinel_one" "example" {
   name    = "SentinelOne Integration"
-  host    = "domain.sentinelone.net"
+  host    = "https://domain.sentinelone.net"
   account = "Your Account"
 
   credentials = {

--- a/internal/provider/integration_sentinel_one_resource.go
+++ b/internal/provider/integration_sentinel_one_resource.go
@@ -6,6 +6,7 @@ package provider
 import (
 	"context"
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -99,8 +100,11 @@ func (r *integrationSentinelOneResource) Schema(_ context.Context, _ resource.Sc
 			},
 			// SentinelOne options
 			"host": schema.StringAttribute{
-				MarkdownDescription: "The host of the SentinelOne integration.",
+				MarkdownDescription: "The host of the SentinelOne integration. Must include URL scheme, e.g., https://domain.sentinelone.net.",
 				Required:            true,
+				Validators: []validator.String{
+					stringvalidator.RegexMatches(regexp.MustCompile("^https?://"), "must include URL scheme (http:// or https://)"),
+				},
 			},
 			"account": schema.StringAttribute{
 				MarkdownDescription: "The account ID of the SentinelOne integration.",

--- a/internal/provider/integration_sentinel_one_resource_test.go
+++ b/internal/provider/integration_sentinel_one_resource_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccSentinelOneIntegrationResource(t *testing.T) {
@@ -58,6 +59,17 @@ func TestAccSentinelOneIntegrationResource(t *testing.T) {
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "host", "https://new-host"),
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "account", "new-account"),
 				),
+			},
+			// Import testing
+			{
+				ResourceName: "mondoo_integration_sentinel_one.test",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					return s.RootModule().Resources["mondoo_integration_sentinel_one.test"].Primary.Attributes["mrn"], nil
+				},
+				ImportStateVerifyIdentifierAttribute: "mrn",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIgnore:              []string{"credentials"},
 			},
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/integration_sentinel_one_resource_test.go
+++ b/internal/provider/integration_sentinel_one_resource_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -15,41 +16,46 @@ func TestAccSentinelOneIntegrationResource(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
+			// Validation failure when host has no scheme
+			{
+				Config:      testAccSentinelOneIntegrationResourceConfig(accSpace.ID(), "invalid", "host-without-scheme", "account", "secret"),
+				ExpectError: regexp.MustCompile("scheme"),
+			},
 			// Create and Read testing
 			{
-				Config: testAccSentinelOneIntegrationResourceConfig(accSpace.ID(), "one", "host", "account", "secret"),
+				Config: testAccSentinelOneIntegrationResourceConfig(accSpace.ID(), "one", "https://host", "account", "secret"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "name", "one"),
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "space_id", accSpace.ID()),
-					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "host", "host"),
+					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "host", "https://host"),
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "account", "account"),
 				),
 			},
 			{
-				Config: testAccSentinelOneIntegrationResourceWithSpaceInProviderConfig(accSpace.ID(), "two", "host", "account", "cert"),
+				Config: testAccSentinelOneIntegrationResourceWithSpaceInProviderConfig(accSpace.ID(), "two", "https://host", "account", "cert"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "name", "two"),
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "space_id", accSpace.ID()),
-					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "host", "host"),
+					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "host", "https://host"),
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "account", "account"),
 				),
 			},
 			// Update and Read testing
 			{
-				Config: testAccSentinelOneIntegrationResourceConfig(accSpace.ID(), "three", "new-host", "new-account", "secret"),
+				Config: testAccSentinelOneIntegrationResourceConfig(accSpace.ID(), "three", "https://new-host", "new-account", "secret"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "name", "three"),
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "space_id", accSpace.ID()),
-					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "host", "new-host"),
+					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "host", "https://new-host"),
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "account", "new-account"),
 				),
 			},
 			{
-				Config: testAccSentinelOneIntegrationResourceWithSpaceInProviderConfig(accSpace.ID(), "four", "new-host", "new-account", "cert"),
+				Config: testAccSentinelOneIntegrationResourceWithSpaceInProviderConfig(accSpace.ID(), "four", "https://new-host", "new-account", "cert"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "name", "four"),
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "space_id", accSpace.ID()),
-					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "host", "new-host"),
+					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "host", "https://new-host"),
 					resource.TestCheckResourceAttr("mondoo_integration_sentinel_one.test", "account", "new-account"),
 				),
 			},


### PR DESCRIPTION
This PR updates the SentinelOne documentation to specify that the host protocol is required. It also adds some basic validation to make sure this is actually the case. 

Fixes: #283 