### PR TITLE
🐛 SentinelOne Import Error Fix

### DIFF
--- a/internal/provider/integration_sentinel_one_resource.go
+++ b/internal/provider/integration_sentinel_one_resource.go
@@ -188,6 +188,7 @@ func (r *integrationSentinelOneResource) Create(ctx context.Context, req resourc
 	}
 
 	// trigger integration to gather results quickly after the first setup
+	// NOTE: we ignore the error since the integration state does not depend on it
 	_, err = r.client.TriggerAction(ctx,
 		string(integration.Mrn),
 		mondoov1.ActionTypeRunImport,
@@ -200,7 +201,6 @@ func (r *integrationSentinelOneResource) Create(ctx context.Context, req resourc
 					"Unable to trigger integration. Got error: %s", err,
 				),
 			)
-		return
 	}
 
 	// Save space mrn into the Terraform state.


### PR DESCRIPTION
This PR removes the early return from the Create of SentinelOne if the initial trigger fails. This is to match what other resources such as CrowdStrike do, treat it as a true warning in this case since the state is still valid and the resource is still created.

Fixes: #282 