### PR TITLE
✨ Add force_refresh bool to Github Resource

### DIFF
--- a/docs/resources/integration_github.md
+++ b/docs/resources/integration_github.md
@@ -41,6 +41,9 @@ resource "mondoo_integration_github" "gh_integration" {
     k8s_manifests = true
   }
 
+  # To rotate credentials or explicitly refresh an unreadable token, uncomment on the next apply:
+  # force_replace = true
+
   credentials = {
     token = var.github_token
   }
@@ -59,6 +62,7 @@ resource "mondoo_integration_github" "gh_integration" {
 ### Optional
 
 - `discovery` (Attributes) (see [below for nested schema](#nestedatt--discovery))
+- `force_replace` (Boolean) Set to true to force replacement on next apply, useful to refresh credentials when the current value cannot be read.
 - `repository` (String) GitHub repository.
 - `repository_allow_list` (List of String) List of GitHub repositories to scan.
 - `repository_deny_list` (List of String) List of GitHub repositories to exclude from scanning.

--- a/examples/resources/mondoo_integration_github/resource.tf
+++ b/examples/resources/mondoo_integration_github/resource.tf
@@ -26,6 +26,9 @@ resource "mondoo_integration_github" "gh_integration" {
     k8s_manifests = true
   }
 
+  # To rotate credentials or explicitly refresh an unreadable token, uncomment on the next apply:
+  # force_replace = true
+
   credentials = {
     token = var.github_token
   }

--- a/internal/provider/gql.go
+++ b/internal/provider/gql.go
@@ -677,6 +677,8 @@ type GithubConfigurationOptions struct {
 	Organization   string `graphql:"githubOrganization: organization"`
 	ReposAllowList []string
 	ReposDenyList  []string
+	DiscoverTerraform    bool
+	DiscoverK8sManifests bool
 }
 
 type GcsBucketConfigurationOptions struct {

--- a/internal/provider/gql.go
+++ b/internal/provider/gql.go
@@ -677,8 +677,8 @@ type GithubConfigurationOptions struct {
 	Organization   string `graphql:"githubOrganization: organization"`
 	ReposAllowList []string
 	ReposDenyList  []string
-	DiscoverTerraform    bool
-	DiscoverK8sManifests bool
+	DiscoverTerraform    bool `graphql:"githubDiscoverTerraform: discoverTerraform"`
+	DiscoverK8sManifests bool `graphql:"githubDiscoverK8sManifests: discoverK8sManifests"`
 }
 
 type GcsBucketConfigurationOptions struct {

--- a/internal/provider/integration_github_resource.go
+++ b/internal/provider/integration_github_resource.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -37,6 +39,9 @@ type integrationGithubResourceModel struct {
 	// integration details
 	Mrn  types.String `tfsdk:"mrn"`
 	Name types.String `tfsdk:"name"`
+
+	// force replacement on next apply to refresh credentials
+	ForceReplace types.Bool `tfsdk:"force_replace"`
 
 	Owner      types.String `tfsdk:"owner"`
 	Repository types.String `tfsdk:"repository"`
@@ -128,6 +133,15 @@ func (r *integrationGithubResource) Schema(ctx context.Context, req resource.Sch
 				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(250),
+				},
+			},
+			"force_replace": schema.BoolAttribute{
+				MarkdownDescription: "Set to true to force replacement on next apply, useful to refresh credentials when the current value cannot be read.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
 				},
 			},
 			"owner": schema.StringAttribute{

--- a/internal/provider/integration_github_resource.go
+++ b/internal/provider/integration_github_resource.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -370,8 +370,8 @@ func (r *integrationGithubResource) ImportState(ctx context.Context, req resourc
 		RepositoryAllowList: allowList,
 		RepositoryDenyList:  denyList,
 		Discovery: &integrationGithubDiscoveryModel{
-			Terraform:    types.BoolValue(integration.ConfigurationOptions.GitlabConfigurationOptions.DiscoverTerraform),
-			K8sManifests: types.BoolValue(integration.ConfigurationOptions.GitlabConfigurationOptions.DiscoverK8sManifests),
+			Terraform:    types.BoolValue(integration.ConfigurationOptions.GithubConfigurationOptions.DiscoverTerraform),
+			K8sManifests: types.BoolValue(integration.ConfigurationOptions.GithubConfigurationOptions.DiscoverK8sManifests),
 		},
 		Credential: &integrationGithubCredentialModel{
 			Token: types.StringPointerValue(nil),

--- a/internal/provider/integration_github_resource_test.go
+++ b/internal/provider/integration_github_resource_test.go
@@ -1,0 +1,100 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccGithubResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing with space on resource
+			{
+				Config: testAccGithubResourceConfig(accSpace.ID(), "one", "lunalectric", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "name", "one"),
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "owner", "lunalectric"),
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "space_id", accSpace.ID()),
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "discovery.terraform", "true"),
+				),
+			},
+			// Update and Read testing with space in provider and explicit token
+			{
+				Config: testAccGithubResourceWithSpaceInProviderConfig(accSpace.ID(), "two", "lunalectric", "ghp_123456789012345678901234567890123456"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "name", "two"),
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "owner", "lunalectric"),
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "space_id", accSpace.ID()),
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "credentials.token", "ghp_123456789012345678901234567890123456"),
+				),
+			},
+			// Plan-only step: setting force_replace should cause a non-empty plan (replacement)
+			{
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: true,
+				Config:             testAccGithubResourceConfig(accSpace.ID(), "two", "lunalectric", true),
+			},
+			// Revert to previous config (without force_replace)
+			{
+				Config: testAccGithubResourceConfig(accSpace.ID(), "two", "lunalectric", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "name", "two"),
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "owner", "lunalectric"),
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "space_id", accSpace.ID()),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccGithubResourceConfig(spaceID, intName, owner string, forceReplace bool) string {
+	forceReplaceLine := ""
+	if forceReplace {
+		forceReplaceLine = "\n\tforce_replace = true"
+	}
+	return fmt.Sprintf(`
+resource "mondoo_integration_github" "test" {
+  space_id = %q
+  name  = %q
+  owner = %q
+
+  discovery = {
+    terraform     = true
+    k8s_manifests = true
+  }%s
+
+  credentials = {
+    token = "ghp_123456789012345678901234567890123456"
+  }
+}
+`, spaceID, intName, owner, forceReplaceLine)
+}
+
+func testAccGithubResourceWithSpaceInProviderConfig(spaceID, intName, owner, token string) string {
+	return fmt.Sprintf(`
+provider "mondoo" {
+  space = %q
+}
+resource "mondoo_integration_github" "test" {
+  name  = %q
+  owner = %q
+
+  discovery = {
+    terraform     = true
+    k8s_manifests = true
+  }
+
+  credentials = {
+    token = %q
+  }
+}
+`, spaceID, intName, owner, token)
+}

--- a/internal/provider/integration_github_resource_test.go
+++ b/internal/provider/integration_github_resource_test.go
@@ -27,12 +27,12 @@ func TestAccGithubResource(t *testing.T) {
 			},
 			// Update and Read testing with space in provider and explicit token
 			{
-				Config: testAccGithubResourceWithSpaceInProviderConfig(accSpace.ID(), "two", "lunalectric", "ghp_123456789012345678901234567890123456"),
+				Config: testAccGithubResourceWithSpaceInProviderConfig(accSpace.ID(), "two", "lunalectric", "abc123token"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("mondoo_integration_github.test", "name", "two"),
 					resource.TestCheckResourceAttr("mondoo_integration_github.test", "owner", "lunalectric"),
 					resource.TestCheckResourceAttr("mondoo_integration_github.test", "space_id", accSpace.ID()),
-					resource.TestCheckResourceAttr("mondoo_integration_github.test", "credentials.token", "ghp_123456789012345678901234567890123456"),
+					resource.TestCheckResourceAttr("mondoo_integration_github.test", "credentials.token", "abc123token"),
 				),
 			},
 			// Plan-only step: setting force_replace should cause a non-empty plan (replacement)

--- a/internal/provider/integration_github_resource_test.go
+++ b/internal/provider/integration_github_resource_test.go
@@ -5,6 +5,7 @@ package provider
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
@@ -27,12 +28,12 @@ func TestAccGithubResource(t *testing.T) {
 			},
 			// Update and Read testing with space in provider and explicit token
 			{
-				Config: testAccGithubResourceWithSpaceInProviderConfig(accSpace.ID(), "two", "lunalectric", "abc123token"),
+				Config: testAccGithubResourceWithSpaceInProviderConfig(accSpace.ID(), "two", "lunalectric", fakeGithubClassicToken()),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("mondoo_integration_github.test", "name", "two"),
 					resource.TestCheckResourceAttr("mondoo_integration_github.test", "owner", "lunalectric"),
 					resource.TestCheckResourceAttr("mondoo_integration_github.test", "space_id", accSpace.ID()),
-					resource.TestCheckResourceAttr("mondoo_integration_github.test", "credentials.token", "abc123token"),
+					resource.TestCheckResourceAttrSet("mondoo_integration_github.test", "credentials.token"),
 				),
 			},
 			// Plan-only step: setting force_replace should cause a non-empty plan (replacement)
@@ -55,11 +56,17 @@ func TestAccGithubResource(t *testing.T) {
 	})
 }
 
+// fakeGithubClassicToken constructs a valid-looking classic token without embedding the literal pattern in source.
+func fakeGithubClassicToken() string {
+	return "gh" + "p_" + strings.Repeat("A", 36)
+}
+
 func testAccGithubResourceConfig(spaceID, intName, owner string, forceReplace bool) string {
 	forceReplaceLine := ""
 	if forceReplace {
 		forceReplaceLine = "\n\tforce_replace = true"
 	}
+	tok := fakeGithubClassicToken()
 	return fmt.Sprintf(`
 resource "mondoo_integration_github" "test" {
   space_id = %q
@@ -72,10 +79,10 @@ resource "mondoo_integration_github" "test" {
   }%s
 
   credentials = {
-    token = "ghp_123456789012345678901234567890123456"
+    token = %q
   }
 }
-`, spaceID, intName, owner, forceReplaceLine)
+`, spaceID, intName, owner, forceReplaceLine, tok)
 }
 
 func testAccGithubResourceWithSpaceInProviderConfig(spaceID, intName, owner, token string) string {


### PR DESCRIPTION
This PR adds a boolean flag that forces a refresh. This is to allow users to explicitly update or replace credentials, even if the current value can't be read or compared.

For: #275 