### PR TITLE
🧹 use query mrns on exceptions test

### DIFF
--- a/internal/provider/exception_resource_test.go
+++ b/internal/provider/exception_resource_test.go
@@ -72,8 +72,8 @@ func testCreateException(spaceId string, spaceMrn string, action string) string 
 		action        = "%s"
 		valid_until = "2025-09-09"
 		check_mrns = [
-			"//policy.api.mondoo.app/policies/cis-microsoft-azure-windows-server-2022-dc-level-1",
-			"//policy.api.mondoo.app/policies/cis-microsoft-azure-windows-server-2022-ms-level-1",
+			"//policy.api.mondoo.app/queries/cis-microsoft-azure-windows-server-2022--2.3.1.1",
+			"//policy.api.mondoo.app/queries/cis-microsoft-azure-windows-server-2022--2.3.1.3",
 		]
 		depends_on = [
 			mondoo_policy_assignment.cis_policy_assignment_enabled


### PR DESCRIPTION
bad copy paste on my part resulted in me putting the policy mrn instead of the query mrn for the exception