### PR TITLE
Remove deprecated ebs_scan_options from docs

### DIFF
--- a/docs/resources/integration_aws_serverless.md
+++ b/docs/resources/integration_aws_serverless.md
@@ -60,12 +60,8 @@ resource "mondoo_integration_aws_serverless" "aws_serverless" {
     ecs_scan           = false
     cron_scan_in_hours = 24
     ec2_scan_options = {
-      ssm             = true
-      ebs_volume_scan = true
-      ebs_scan_options = {
-        target_instances_per_scanner = 5
-        max_asg_instances            = 10
-      }
+      ssm              = true
+      ebs_volume_scan  = true
       instance_connect = false
     }
   }

--- a/examples/resources/mondoo_integration_aws_serverless/resource.tf
+++ b/examples/resources/mondoo_integration_aws_serverless/resource.tf
@@ -45,12 +45,8 @@ resource "mondoo_integration_aws_serverless" "aws_serverless" {
     ecs_scan           = false
     cron_scan_in_hours = 24
     ec2_scan_options = {
-      ssm             = true
-      ebs_volume_scan = true
-      ebs_scan_options = {
-        target_instances_per_scanner = 5
-        max_asg_instances            = 10
-      }
+      ssm              = true
+      ebs_volume_scan  = true
       instance_connect = false
     }
   }


### PR DESCRIPTION
Removes the deprecated `ebs_scan_options` from the docs