### PR TITLE
Add vscode launch target to debug the provider

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Terraform Provider",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            // this assumes your workspace is the root of the repo
+            "program": "${workspaceFolder}",
+            "env": {},
+            "args": [
+                "-debug",
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
How to use it:
- Open vscode. Make sure that your MONDOO_CONFIG_PATH is in the environment before launching
- Go to the debug tab
- Click `Debug Terraform Provider`
- It will launch, and in the `Debug Console` print something like 
``` 
Provider started. To attach Terraform CLI, set the TF_REATTACH_PROVIDERS environment variable with the following:

	TF_REATTACH_PROVIDERS='{"registry.terraform.io/mondoo/mondoo":{"Protocol":"grpc","ProtocolVersion":6,"Pid":4069939,"Test":true,"Addr":{"Network":"unix","String":"/tmp/plugin12816029"}}}'
  ```
- Before running terraform, export `TF_REATTACH_PROVIDERS`
- Run terraform as normal. Every time you restart the provider, you must reexport the variable