### PR TITLE
🐛 remove errors from set roles

### DIFF
--- a/internal/provider/gql.go
+++ b/internal/provider/gql.go
@@ -1264,8 +1264,7 @@ type SetRolesInput struct {
 }
 
 type SetRolesPayload struct {
-	Mrns   []mondoov1.String `json:"mrns"`
-	Errors mondoov1.String   `json:"errors"`
+	Mrns []mondoov1.String `json:"mrns"`
 }
 
 func (c *ExtendedGqlClient) SetRoles(ctx context.Context, input SetRolesInput) (SetRolesPayload, error) {


### PR DESCRIPTION
- Its type is actually Map, which is a non standard type
- The underlying library cannot support Map
- The backend will now return the error properly