### PR TITLE
Fix AWS region attribute and add exclude tags filter

### DIFF
--- a/docs/resources/integration_aws_serverless.md
+++ b/docs/resources/integration_aws_serverless.md
@@ -49,7 +49,7 @@ data "aws_region" "current" {}
 # Setup the AWS integration
 resource "mondoo_integration_aws_serverless" "aws_serverless" {
   name                          = "AWS Integration"
-  region                        = data.aws_region.current.name
+  region                        = data.aws_region.current.region
   is_organization               = false
   console_sign_in_trigger       = true
   instance_state_change_trigger = true
@@ -63,6 +63,10 @@ resource "mondoo_integration_aws_serverless" "aws_serverless" {
       ssm              = true
       ebs_volume_scan  = true
       instance_connect = false
+      exclude_tags_filter = {
+        "Created By" = "Mondoo"
+        "Env"        = "dev"
+      }
     }
   }
 }

--- a/examples/resources/mondoo_integration_aws_serverless/resource.tf
+++ b/examples/resources/mondoo_integration_aws_serverless/resource.tf
@@ -34,7 +34,7 @@ data "aws_region" "current" {}
 # Setup the AWS integration
 resource "mondoo_integration_aws_serverless" "aws_serverless" {
   name                          = "AWS Integration"
-  region                        = data.aws_region.current.name
+  region                        = data.aws_region.current.region
   is_organization               = false
   console_sign_in_trigger       = true
   instance_state_change_trigger = true
@@ -48,6 +48,10 @@ resource "mondoo_integration_aws_serverless" "aws_serverless" {
       ssm              = true
       ebs_volume_scan  = true
       instance_connect = false
+      exclude_tags_filter = {
+        "Created By" = "Mondoo"
+        "Env"        = "dev"
+      }
     }
   }
 }


### PR DESCRIPTION
Update AWS integration configuration to use the correct (non deprecated) region attribute and add exclude tags filter for EC2 scan options.