### PR TITLE
Fix space settings update

### DIFF
--- a/internal/provider/space_resource.go
+++ b/internal/provider/space_resource.go
@@ -251,9 +251,13 @@ func (r *SpaceResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						Optional:            true,
 						Computed:            true,
 						MarkdownDescription: "Terminated assets configuration for the space.",
+						PlanModifiers: []planmodifier.Object{
+							objectplanmodifier.UseStateForUnknown(),
+						},
 						Attributes: map[string]schema.Attribute{
 							"cleanup": schema.BoolAttribute{
-								Required:            true,
+								Optional:            true,
+								Computed:            true,
 								MarkdownDescription: "Whether to cleanup terminated assets.",
 							},
 						},
@@ -262,9 +266,13 @@ func (r *SpaceResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						Optional:            true,
 						Computed:            true,
 						MarkdownDescription: "Unused service accounts configuration for the space.",
+						PlanModifiers: []planmodifier.Object{
+							objectplanmodifier.UseStateForUnknown(),
+						},
 						Attributes: map[string]schema.Attribute{
 							"cleanup": schema.BoolAttribute{
-								Required:            true,
+								Optional:            true,
+								Computed:            true,
 								MarkdownDescription: "Whether to cleanup unused service accounts.",
 							},
 						},
@@ -284,6 +292,7 @@ func (r *SpaceResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 							},
 							"after_days": schema.Int32Attribute{
 								Optional:            true,
+								Computed:            true,
 								MarkdownDescription: "After how many days to garbage collect. ",
 							},
 						},
@@ -297,7 +306,8 @@ func (r *SpaceResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 						},
 						Attributes: map[string]schema.Attribute{
 							"enabled": schema.BoolAttribute{
-								Required:            true,
+								Optional:            true,
+								Computed:            true,
 								MarkdownDescription: "Whether to enable platform vulnerability analysis.",
 							},
 						},


### PR DESCRIPTION
```
After the apply operation, the provider still indicated an unknown value for
mondoo_space.foo.space_settings.terminated_assets_configuration.
All values must be known after apply, so this is always a bug in the provider
and should be reported in the provider's own repository. Terraform will still
save the other known object values in the state.
```

Changed it to take unknown values from the plan