### PR TITLE
🐛 ignore ordering for workspaces key-value conditions

### DIFF
--- a/docs/resources/workspace.md
+++ b/docs/resources/workspace.md
@@ -113,7 +113,7 @@ Required:
 
 - `field` (String) key:value field to match. Valid values: ["LABELS" "ANNOTATIONS"]
 - `operator` (String) Rating operator. Valid values: ["CONTAINS"]
-- `values` (Attributes List) key:value list to match. Values are ORed together. (see [below for nested schema](#nestedatt--asset_selections--conditions--key_value_condition--values))
+- `values` (Attributes Set) key:value list to match. Values are ORed together. (see [below for nested schema](#nestedatt--asset_selections--conditions--key_value_condition--values))
 
 <a id="nestedatt--asset_selections--conditions--key_value_condition--values"></a>
 ### Nested Schema for `asset_selections.conditions.key_value_condition.values`

--- a/internal/provider/workspace_resource.go
+++ b/internal/provider/workspace_resource.go
@@ -225,7 +225,7 @@ func (r *WorkspaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 												),
 												Required: true,
 											},
-											"values": schema.ListNestedAttribute{
+											"values": schema.SetNestedAttribute{
 												MarkdownDescription: "key:value list to match. Values are ORed together.",
 												Required:            true,
 												NestedObject: schema.NestedAttributeObject{


### PR DESCRIPTION
This should ignore ordering and avoid having issues with state not matching