### PR TITLE
✨ Add asset routing table and rule resources

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,12 @@ jobs:
           - '1.11.*'
           - '1.12.*'
           - '1.13.*'
+        include:
+          # Org-scoped asset routing tests mutate shared state, so only run them
+          # on a single Terraform version to avoid parallel conflicts.
+          # Other entries get run_asset_routing_tests="" which the Go tests treat as false.
+          - terraform: '1.13.*'
+            run_asset_routing_tests: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -79,6 +85,7 @@ jobs:
       - env:
           TF_ACC: "1"
           MONDOO_CONFIG_BASE64: ${{ secrets.MONDOO_CONFIG_BASE64 }}
+          RUN_ASSET_ROUTING_TESTS: ${{ matrix.run_asset_routing_tests }}
         run: go test -v -cover ./internal/provider/
         timeout-minutes: 10
 

--- a/examples/resources/mondoo_asset_routing_rule/main.tf
+++ b/examples/resources/mondoo_asset_routing_rule/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    mondoo = {
+      source = "mondoohq/mondoo"
+    }
+  }
+}
+
+provider "mondoo" {}

--- a/examples/resources/mondoo_asset_routing_rule/main.tf
+++ b/examples/resources/mondoo_asset_routing_rule/main.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     mondoo = {
-      source = "mondoohq/mondoo"
+      source  = "mondoohq/mondoo"
+      version = ">= 0.19"
     }
   }
 }

--- a/examples/resources/mondoo_asset_routing_rule/main.tf
+++ b/examples/resources/mondoo_asset_routing_rule/main.tf
@@ -6,5 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {}

--- a/examples/resources/mondoo_asset_routing_rule/resource.tf
+++ b/examples/resources/mondoo_asset_routing_rule/resource.tf
@@ -1,0 +1,28 @@
+# Manage individual routing rules independently.
+# Ideal for multi-team setups where each team manages their own rules.
+
+resource "mondoo_asset_routing_rule" "production" {
+  org_mrn          = "//captain.api.mondoo.app/organizations/my-org-id"
+  target_space_mrn = "//captain.api.mondoo.app/spaces/prod-space"
+  priority         = 10
+
+  condition {
+    field    = "LABEL"
+    operator = "EQUAL"
+    key      = "env"
+    values   = ["production"]
+  }
+}
+
+resource "mondoo_asset_routing_rule" "staging" {
+  org_mrn          = "//captain.api.mondoo.app/organizations/my-org-id"
+  target_space_mrn = "//captain.api.mondoo.app/spaces/staging-space"
+  priority         = 20
+
+  condition {
+    field    = "LABEL"
+    operator = "EQUAL"
+    key      = "env"
+    values   = ["staging"]
+  }
+}

--- a/examples/resources/mondoo_asset_routing_rule/resource.tf
+++ b/examples/resources/mondoo_asset_routing_rule/resource.tf
@@ -1,9 +1,30 @@
+variable "org_id" {
+  description = "The ID of the organization"
+  type        = string
+}
+
+provider "mondoo" {}
+
+data "mondoo_organization" "current" {
+  id = var.org_id
+}
+
+# Create spaces for routing targets
+resource "mondoo_space" "production" {
+  name   = "production"
+  org_id = var.org_id
+}
+
+resource "mondoo_space" "staging" {
+  name   = "staging"
+  org_id = var.org_id
+}
+
 # Manage individual routing rules independently.
 # Ideal for multi-team setups where each team manages their own rules.
-
 resource "mondoo_asset_routing_rule" "production" {
-  org_mrn          = "//captain.api.mondoo.app/organizations/my-org-id"
-  target_space_mrn = "//captain.api.mondoo.app/spaces/prod-space"
+  org_mrn          = data.mondoo_organization.current.mrn
+  target_space_mrn = mondoo_space.production.mrn
   priority         = 10
 
   condition {
@@ -15,8 +36,8 @@ resource "mondoo_asset_routing_rule" "production" {
 }
 
 resource "mondoo_asset_routing_rule" "staging" {
-  org_mrn          = "//captain.api.mondoo.app/organizations/my-org-id"
-  target_space_mrn = "//captain.api.mondoo.app/spaces/staging-space"
+  org_mrn          = data.mondoo_organization.current.mrn
+  target_space_mrn = mondoo_space.staging.mrn
   priority         = 20
 
   condition {

--- a/examples/resources/mondoo_asset_routing_table/main.tf
+++ b/examples/resources/mondoo_asset_routing_table/main.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_providers {
+    mondoo = {
+      source = "mondoohq/mondoo"
+    }
+  }
+}
+
+provider "mondoo" {}

--- a/examples/resources/mondoo_asset_routing_table/main.tf
+++ b/examples/resources/mondoo_asset_routing_table/main.tf
@@ -1,7 +1,8 @@
 terraform {
   required_providers {
     mondoo = {
-      source = "mondoohq/mondoo"
+      source  = "mondoohq/mondoo"
+      version = ">= 0.19"
     }
   }
 }

--- a/examples/resources/mondoo_asset_routing_table/main.tf
+++ b/examples/resources/mondoo_asset_routing_table/main.tf
@@ -6,5 +6,3 @@ terraform {
     }
   }
 }
-
-provider "mondoo" {}

--- a/examples/resources/mondoo_asset_routing_table/resource.tf
+++ b/examples/resources/mondoo_asset_routing_table/resource.tf
@@ -1,11 +1,38 @@
+variable "org_id" {
+  description = "The ID of the organization"
+  type        = string
+}
+
+provider "mondoo" {}
+
+data "mondoo_organization" "current" {
+  id = var.org_id
+}
+
+# Create spaces for routing targets
+resource "mondoo_space" "linux" {
+  name   = "linux-assets"
+  org_id = var.org_id
+}
+
+resource "mondoo_space" "windows" {
+  name   = "windows-assets"
+  org_id = var.org_id
+}
+
+resource "mondoo_space" "catch_all" {
+  name   = "catch-all"
+  org_id = var.org_id
+}
+
 # Manage the entire routing table for an organization.
 # Priority is derived from the order of rules (first = highest priority).
 resource "mondoo_asset_routing_table" "example" {
-  org_mrn = "//captain.api.mondoo.app/organizations/my-org-id"
+  org_mrn = data.mondoo_organization.current.mrn
 
   # Rule 1: Route Linux assets
   rule {
-    target_space_mrn = "//captain.api.mondoo.app/spaces/linux-space"
+    target_space_mrn = mondoo_space.linux.mrn
 
     condition {
       field    = "PLATFORM"
@@ -16,7 +43,7 @@ resource "mondoo_asset_routing_table" "example" {
 
   # Rule 2: Route Windows assets
   rule {
-    target_space_mrn = "//captain.api.mondoo.app/spaces/windows-space"
+    target_space_mrn = mondoo_space.windows.mrn
 
     condition {
       field    = "PLATFORM"
@@ -27,6 +54,6 @@ resource "mondoo_asset_routing_table" "example" {
 
   # Rule 3: Catch-all for everything else
   rule {
-    target_space_mrn = "//captain.api.mondoo.app/spaces/catch-all-space"
+    target_space_mrn = mondoo_space.catch_all.mrn
   }
 }

--- a/examples/resources/mondoo_asset_routing_table/resource.tf
+++ b/examples/resources/mondoo_asset_routing_table/resource.tf
@@ -1,0 +1,32 @@
+# Manage the entire routing table for an organization.
+# Priority is derived from the order of rules (first = highest priority).
+resource "mondoo_asset_routing_table" "example" {
+  org_mrn = "//captain.api.mondoo.app/organizations/my-org-id"
+
+  # Rule 1: Route Linux assets
+  rule {
+    target_space_mrn = "//captain.api.mondoo.app/spaces/linux-space"
+
+    condition {
+      field    = "PLATFORM"
+      operator = "EQUAL"
+      values   = ["ubuntu", "debian", "rhel", "amazonlinux"]
+    }
+  }
+
+  # Rule 2: Route Windows assets
+  rule {
+    target_space_mrn = "//captain.api.mondoo.app/spaces/windows-space"
+
+    condition {
+      field    = "PLATFORM"
+      operator = "EQUAL"
+      values   = ["windows"]
+    }
+  }
+
+  # Rule 3: Catch-all for everything else
+  rule {
+    target_space_mrn = "//captain.api.mondoo.app/spaces/catch-all-space"
+  }
+}

--- a/internal/provider/asset_routing_common.go
+++ b/internal/provider/asset_routing_common.go
@@ -18,26 +18,31 @@ type AssetRoutingConditionModel struct {
 	Key      types.String `tfsdk:"key"`
 }
 
-// assetRoutingConditionSchemaAttributes returns the schema attributes for a routing condition,
+// assetRoutingConditionSchemaBlock returns a ListNestedBlock for routing conditions,
 // reusable by both the table and rule resources.
-func assetRoutingConditionSchemaAttributes() map[string]schema.Attribute {
-	return map[string]schema.Attribute{
-		"field": schema.StringAttribute{
-			MarkdownDescription: "The field to match on. Valid values: `HOSTNAME`, `PLATFORM`, `LABEL`.",
-			Required:            true,
-		},
-		"operator": schema.StringAttribute{
-			MarkdownDescription: "The comparison operator. Valid values: `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `MATCHES`.",
-			Required:            true,
-		},
-		"values": schema.ListAttribute{
-			MarkdownDescription: "List of values to match against. A condition matches if the field matches any of the listed values (OR logic).",
-			Required:            true,
-			ElementType:         types.StringType,
-		},
-		"key": schema.StringAttribute{
-			MarkdownDescription: "The label key to match on. Required when `field` is `LABEL`.",
-			Optional:            true,
+func assetRoutingConditionSchemaBlock() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		MarkdownDescription: "Conditions that must all match for this rule to apply (AND logic). If empty, the rule matches all assets (catch-all).",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"field": schema.StringAttribute{
+					MarkdownDescription: "The field to match on. Valid values: `HOSTNAME`, `PLATFORM`, `LABEL`.",
+					Required:            true,
+				},
+				"operator": schema.StringAttribute{
+					MarkdownDescription: "The comparison operator. Valid values: `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `MATCHES`.",
+					Required:            true,
+				},
+				"values": schema.ListAttribute{
+					MarkdownDescription: "List of values to match against. A condition matches if the field matches any of the listed values (OR logic).",
+					Required:            true,
+					ElementType:         types.StringType,
+				},
+				"key": schema.StringAttribute{
+					MarkdownDescription: "The label key to match on. Required when `field` is `LABEL`.",
+					Optional:            true,
+				},
+			},
 		},
 	}
 }

--- a/internal/provider/asset_routing_common.go
+++ b/internal/provider/asset_routing_common.go
@@ -1,4 +1,4 @@
-// Copyright (c) Mondoo, Inc.
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package provider

--- a/internal/provider/asset_routing_common.go
+++ b/internal/provider/asset_routing_common.go
@@ -4,7 +4,11 @@
 package provider
 
 import (
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	mondoov1 "go.mondoo.com/mondoo-go"
 )
@@ -28,10 +32,16 @@ func assetRoutingConditionSchemaBlock() schema.ListNestedBlock {
 				"field": schema.StringAttribute{
 					MarkdownDescription: "The field to match on. Valid values: `HOSTNAME`, `PLATFORM`, `LABEL`.",
 					Required:            true,
+					Validators: []validator.String{
+						stringvalidator.OneOf("HOSTNAME", "PLATFORM", "LABEL"),
+					},
 				},
 				"operator": schema.StringAttribute{
 					MarkdownDescription: "The comparison operator. Valid values: `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `MATCHES`.",
 					Required:            true,
+					Validators: []validator.String{
+						stringvalidator.OneOf("EQUAL", "NOT_EQUAL", "CONTAINS", "MATCHES"),
+					},
 				},
 				"values": schema.ListAttribute{
 					MarkdownDescription: "List of values to match against. A condition matches if the field matches any of the listed values (OR logic).",
@@ -72,6 +82,10 @@ func conditionsFromModel(conditions []AssetRoutingConditionModel) []AssetRouting
 		result[i] = input
 	}
 	return result
+}
+
+func isNotFoundError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "code = NotFound")
 }
 
 // conditionsToModel converts GraphQL condition payloads to Terraform models.

--- a/internal/provider/asset_routing_common.go
+++ b/internal/provider/asset_routing_common.go
@@ -1,0 +1,92 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	mondoov1 "go.mondoo.com/mondoo-go"
+)
+
+// AssetRoutingConditionModel is the Terraform model for a single routing condition.
+// Shared between mondoo_asset_routing_table and mondoo_asset_routing_rule.
+type AssetRoutingConditionModel struct {
+	Field    types.String `tfsdk:"field"`
+	Operator types.String `tfsdk:"operator"`
+	Values   types.List   `tfsdk:"values"`
+	Key      types.String `tfsdk:"key"`
+}
+
+// assetRoutingConditionSchemaAttributes returns the schema attributes for a routing condition,
+// reusable by both the table and rule resources.
+func assetRoutingConditionSchemaAttributes() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"field": schema.StringAttribute{
+			MarkdownDescription: "The field to match on. Valid values: `HOSTNAME`, `PLATFORM`, `LABEL`.",
+			Required:            true,
+		},
+		"operator": schema.StringAttribute{
+			MarkdownDescription: "The comparison operator. Valid values: `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `MATCHES`.",
+			Required:            true,
+		},
+		"values": schema.ListAttribute{
+			MarkdownDescription: "List of values to match against. A condition matches if the field matches any of the listed values (OR logic).",
+			Required:            true,
+			ElementType:         types.StringType,
+		},
+		"key": schema.StringAttribute{
+			MarkdownDescription: "The label key to match on. Required when `field` is `LABEL`.",
+			Optional:            true,
+		},
+	}
+}
+
+// conditionsFromModel converts Terraform condition models to GraphQL input types.
+func conditionsFromModel(conditions []AssetRoutingConditionModel) []AssetRoutingConditionInput {
+	result := make([]AssetRoutingConditionInput, len(conditions))
+	for i, c := range conditions {
+		values := make([]mondoov1.String, 0)
+		if !c.Values.IsNull() && !c.Values.IsUnknown() {
+			for _, v := range c.Values.Elements() {
+				if sv, ok := v.(types.String); ok {
+					values = append(values, mondoov1.String(sv.ValueString()))
+				}
+			}
+		}
+
+		input := AssetRoutingConditionInput{
+			Field:    AssetRoutingConditionField(c.Field.ValueString()),
+			Operator: AssetRoutingConditionOperator(c.Operator.ValueString()),
+			Values:   values,
+		}
+		if !c.Key.IsNull() && !c.Key.IsUnknown() && c.Key.ValueString() != "" {
+			key := mondoov1.String(c.Key.ValueString())
+			input.Key = &key
+		}
+		result[i] = input
+	}
+	return result
+}
+
+// conditionsToModel converts GraphQL condition payloads to Terraform models.
+func conditionsToModel(conditions []AssetRoutingConditionPayload) []AssetRoutingConditionModel {
+	result := make([]AssetRoutingConditionModel, len(conditions))
+	for i, c := range conditions {
+		values := make([]string, len(c.Values))
+		copy(values, c.Values)
+
+		model := AssetRoutingConditionModel{
+			Field:    types.StringValue(c.Field),
+			Operator: types.StringValue(c.Operator),
+			Values:   ConvertListValue(values),
+		}
+		if c.Key != "" {
+			model.Key = types.StringValue(c.Key)
+		} else {
+			model.Key = types.StringNull()
+		}
+		result[i] = model
+	}
+	return result
+}

--- a/internal/provider/asset_routing_rule_resource.go
+++ b/internal/provider/asset_routing_rule_resource.go
@@ -71,13 +71,9 @@ func (r *AssetRoutingRuleResource) Schema(_ context.Context, _ resource.SchemaRe
 					int64planmodifier.UseStateForUnknown(),
 				},
 			},
-			"condition": schema.ListNestedAttribute{
-				MarkdownDescription: "Conditions that must all match for this rule to apply (AND logic). If empty, the rule matches all assets (catch-all).",
-				Optional:            true,
-				NestedObject: schema.NestedAttributeObject{
-					Attributes: assetRoutingConditionSchemaAttributes(),
-				},
-			},
+		},
+		Blocks: map[string]schema.Block{
+			"condition": assetRoutingConditionSchemaBlock(),
 		},
 	}
 }

--- a/internal/provider/asset_routing_rule_resource.go
+++ b/internal/provider/asset_routing_rule_resource.go
@@ -6,10 +6,10 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -67,9 +67,6 @@ func (r *AssetRoutingRuleResource) Schema(_ context.Context, _ resource.SchemaRe
 			"priority": schema.Int64Attribute{
 				MarkdownDescription: "The priority of this rule. Lower values are evaluated first. Rules with the same priority are further sorted by specificity (number of conditions) and MRN.",
 				Required:            true,
-				PlanModifiers: []planmodifier.Int64{
-					int64planmodifier.UseStateForUnknown(),
-				},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -136,6 +133,10 @@ func (r *AssetRoutingRuleResource) Read(ctx context.Context, req resource.ReadRe
 	ruleMrn := data.Mrn.ValueString()
 	result, err := r.client.GetAssetRoutingRule(ctx, ruleMrn)
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Failed to read asset routing rule", err.Error())
 		return
 	}
@@ -229,7 +230,7 @@ func (r *AssetRoutingRuleResource) ImportState(ctx context.Context, req resource
 // Org MRN format: //captain.api.mondoo.app/organizations/{orgId}
 func orgMrnFromRuleMrn(ruleMrn string) (string, error) {
 	const prefix = "//policy.api.mondoo.app/organizations/"
-	if len(ruleMrn) < len(prefix) {
+	if !strings.HasPrefix(ruleMrn, prefix) {
 		return "", fmt.Errorf("invalid rule MRN format: %s", ruleMrn)
 	}
 

--- a/internal/provider/asset_routing_rule_resource.go
+++ b/internal/provider/asset_routing_rule_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) Mondoo, Inc.
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package provider

--- a/internal/provider/asset_routing_rule_resource.go
+++ b/internal/provider/asset_routing_rule_resource.go
@@ -1,0 +1,249 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	mondoov1 "go.mondoo.com/mondoo-go"
+)
+
+var _ resource.Resource = (*AssetRoutingRuleResource)(nil)
+
+func NewAssetRoutingRuleResource() resource.Resource {
+	return &AssetRoutingRuleResource{}
+}
+
+type AssetRoutingRuleResource struct {
+	client *ExtendedGqlClient
+}
+
+type AssetRoutingRuleResourceModel struct {
+	OrgMrn         types.String                 `tfsdk:"org_mrn"`
+	Mrn            types.String                 `tfsdk:"mrn"`
+	TargetSpaceMrn types.String                 `tfsdk:"target_space_mrn"`
+	Priority       types.Int64                  `tfsdk:"priority"`
+	Conditions     []AssetRoutingConditionModel `tfsdk:"condition"`
+}
+
+func (r *AssetRoutingRuleResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_asset_routing_rule"
+}
+
+func (r *AssetRoutingRuleResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: `Manages an individual asset routing rule for a Mondoo organization. This is a **non-authoritative** resource — it manages a single rule without affecting other rules. Multiple rules can coexist and be managed independently, making it ideal for multi-team setups where each team manages their own routing rules.
+
+~> **Warning:** Do not use this resource together with ` + "`mondoo_asset_routing_table`" + ` for the same organization. The table resource replaces all rules atomically, which will overwrite individually managed rules.`,
+
+		Attributes: map[string]schema.Attribute{
+			"org_mrn": schema.StringAttribute{
+				MarkdownDescription: "The Mondoo Resource Name (MRN) of the organization.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"mrn": schema.StringAttribute{
+				MarkdownDescription: "The Mondoo Resource Name (MRN) of the routing rule.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"target_space_mrn": schema.StringAttribute{
+				MarkdownDescription: "The MRN of the space where matching assets will be routed.",
+				Required:            true,
+			},
+			"priority": schema.Int64Attribute{
+				MarkdownDescription: "The priority of this rule. Lower values are evaluated first. Rules with the same priority are further sorted by specificity (number of conditions) and MRN.",
+				Required:            true,
+				PlanModifiers: []planmodifier.Int64{
+					int64planmodifier.UseStateForUnknown(),
+				},
+			},
+			"condition": schema.ListNestedAttribute{
+				MarkdownDescription: "Conditions that must all match for this rule to apply (AND logic). If empty, the rule matches all assets (catch-all).",
+				Optional:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: assetRoutingConditionSchemaAttributes(),
+				},
+			},
+		},
+	}
+}
+
+func (r *AssetRoutingRuleResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*ExtendedGqlClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *ExtendedGqlClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *AssetRoutingRuleResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data AssetRoutingRuleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := CreateAssetRoutingRuleInput{
+		OrgMrn:         mondoov1.String(data.OrgMrn.ValueString()),
+		TargetSpaceMrn: mondoov1.String(data.TargetSpaceMrn.ValueString()),
+		Priority:       mondoov1.Int(data.Priority.ValueInt64()),
+		Conditions:     conditionsFromModel(data.Conditions),
+	}
+
+	tflog.Debug(ctx, "creating asset routing rule", map[string]interface{}{
+		"orgMrn":   data.OrgMrn.ValueString(),
+		"priority": data.Priority.ValueInt64(),
+	})
+
+	result, err := r.client.CreateAssetRoutingRule(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create asset routing rule", err.Error())
+		return
+	}
+
+	data.Mrn = types.StringValue(result.Mrn)
+	data.TargetSpaceMrn = types.StringValue(result.TargetSpaceMrn)
+	data.Priority = types.Int64Value(int64(result.Priority))
+	data.Conditions = conditionsToModel(result.Conditions)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AssetRoutingRuleResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data AssetRoutingRuleResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ruleMrn := data.Mrn.ValueString()
+	result, err := r.client.GetAssetRoutingRule(ctx, ruleMrn)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read asset routing rule", err.Error())
+		return
+	}
+
+	data.Mrn = types.StringValue(result.Mrn)
+	data.TargetSpaceMrn = types.StringValue(result.TargetSpaceMrn)
+	data.Priority = types.Int64Value(int64(result.Priority))
+	data.Conditions = conditionsToModel(result.Conditions)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AssetRoutingRuleResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data AssetRoutingRuleResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := UpdateAssetRoutingRuleInput{
+		RuleMrn:        mondoov1.String(data.Mrn.ValueString()),
+		TargetSpaceMrn: mondoov1.String(data.TargetSpaceMrn.ValueString()),
+		Priority:       mondoov1.Int(data.Priority.ValueInt64()),
+		Conditions:     conditionsFromModel(data.Conditions),
+	}
+
+	tflog.Debug(ctx, "updating asset routing rule", map[string]interface{}{
+		"ruleMrn":  data.Mrn.ValueString(),
+		"priority": data.Priority.ValueInt64(),
+	})
+
+	result, err := r.client.UpdateAssetRoutingRule(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to update asset routing rule", err.Error())
+		return
+	}
+
+	data.Mrn = types.StringValue(result.Mrn)
+	data.TargetSpaceMrn = types.StringValue(result.TargetSpaceMrn)
+	data.Priority = types.Int64Value(int64(result.Priority))
+	data.Conditions = conditionsToModel(result.Conditions)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AssetRoutingRuleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data AssetRoutingRuleResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ruleMrn := data.Mrn.ValueString()
+	tflog.Debug(ctx, "deleting asset routing rule", map[string]interface{}{
+		"ruleMrn": ruleMrn,
+	})
+
+	err := r.client.DeleteAssetRoutingRule(ctx, ruleMrn)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to delete asset routing rule", err.Error())
+	}
+}
+
+func (r *AssetRoutingRuleResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	ruleMrn := req.ID
+
+	result, err := r.client.GetAssetRoutingRule(ctx, ruleMrn)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to import asset routing rule", err.Error())
+		return
+	}
+
+	// Extract org MRN from the rule MRN.
+	// Rule MRN format: //policy.api.mondoo.app/organizations/{orgId}/routing-rules/{ruleId}
+	orgMrn, err := orgMrnFromRuleMrn(ruleMrn)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to parse rule MRN", err.Error())
+		return
+	}
+
+	data := AssetRoutingRuleResourceModel{
+		OrgMrn:         types.StringValue(orgMrn),
+		Mrn:            types.StringValue(result.Mrn),
+		TargetSpaceMrn: types.StringValue(result.TargetSpaceMrn),
+		Priority:       types.Int64Value(int64(result.Priority)),
+		Conditions:     conditionsToModel(result.Conditions),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// orgMrnFromRuleMrn extracts the organization MRN from a routing rule MRN.
+// Rule MRN format: //policy.api.mondoo.app/organizations/{orgId}/routing-rules/{ruleId}
+// Org MRN format: //captain.api.mondoo.app/organizations/{orgId}
+func orgMrnFromRuleMrn(ruleMrn string) (string, error) {
+	const prefix = "//policy.api.mondoo.app/organizations/"
+	if len(ruleMrn) < len(prefix) {
+		return "", fmt.Errorf("invalid rule MRN format: %s", ruleMrn)
+	}
+
+	rest := ruleMrn[len(prefix):]
+	// rest should be "{orgId}/routing-rules/{ruleId}"
+	for i, ch := range rest {
+		if ch == '/' {
+			orgID := rest[:i]
+			return orgPrefix + orgID, nil
+		}
+	}
+	return "", fmt.Errorf("invalid rule MRN format: %s", ruleMrn)
+}

--- a/internal/provider/asset_routing_rule_resource_test.go
+++ b/internal/provider/asset_routing_rule_resource_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Mondoo, Inc.
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package provider

--- a/internal/provider/asset_routing_rule_resource_test.go
+++ b/internal/provider/asset_routing_rule_resource_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccAssetRoutingRuleResource(t *testing.T) {
+	orgID, err := getOrgId()
+	if err != nil {
+		t.Skip("skipping: no org-scoped service account available")
+	}
+	orgMrn := orgPrefix + orgID
+	targetSpaceMrn := accSpace.MRN()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create a rule with platform condition
+			{
+				Config: testAccAssetRoutingRuleConfig(orgMrn, targetSpaceMrn, 10, "PLATFORM", "EQUAL", "ubuntu"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "org_mrn", orgMrn),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "target_space_mrn", targetSpaceMrn),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "priority", "10"),
+					resource.TestCheckResourceAttrSet("mondoo_asset_routing_rule.test", "mrn"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "condition.#", "1"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "condition.0.field", "PLATFORM"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "condition.0.operator", "EQUAL"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "condition.0.values.0", "ubuntu"),
+				),
+			},
+			// Update priority and condition
+			{
+				Config: testAccAssetRoutingRuleConfig(orgMrn, targetSpaceMrn, 20, "HOSTNAME", "CONTAINS", "prod"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "priority", "20"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "condition.0.field", "HOSTNAME"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "condition.0.values.0", "prod"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "mondoo_asset_routing_rule.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func TestAccAssetRoutingRuleResourceWithLabel(t *testing.T) {
+	orgID, err := getOrgId()
+	if err != nil {
+		t.Skip("skipping: no org-scoped service account available")
+	}
+	orgMrn := orgPrefix + orgID
+	targetSpaceMrn := accSpace.MRN()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create a rule with label condition
+			{
+				Config: testAccAssetRoutingRuleLabelConfig(orgMrn, targetSpaceMrn, 10, "env", "production"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "condition.#", "1"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "condition.0.field", "LABEL"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "condition.0.key", "env"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_rule.test", "condition.0.values.0", "production"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAssetRoutingRuleConfig(orgMrn, targetSpaceMrn string, priority int, field, operator, value string) string {
+	return fmt.Sprintf(`
+resource "mondoo_asset_routing_rule" "test" {
+  org_mrn          = %[1]q
+  target_space_mrn = %[2]q
+  priority         = %[3]d
+
+  condition {
+    field    = %[4]q
+    operator = %[5]q
+    values   = [%[6]q]
+  }
+}
+`, orgMrn, targetSpaceMrn, priority, field, operator, value)
+}
+
+func testAccAssetRoutingRuleLabelConfig(orgMrn, targetSpaceMrn string, priority int, key, value string) string {
+	return fmt.Sprintf(`
+resource "mondoo_asset_routing_rule" "test" {
+  org_mrn          = %[1]q
+  target_space_mrn = %[2]q
+  priority         = %[3]d
+
+  condition {
+    field    = "LABEL"
+    operator = "EQUAL"
+    key      = %[4]q
+    values   = [%[5]q]
+  }
+}
+`, orgMrn, targetSpaceMrn, priority, key, value)
+}

--- a/internal/provider/asset_routing_rule_resource_test.go
+++ b/internal/provider/asset_routing_rule_resource_test.go
@@ -5,12 +5,18 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccAssetRoutingRuleResource(t *testing.T) {
+	if os.Getenv("RUN_ASSET_ROUTING_TESTS") != "true" {
+		t.Skip("skipping: asset routing tests only run on a single TF version to avoid parallel conflicts")
+	}
 	orgID, err := getOrgId()
 	if err != nil {
 		t.Skip("skipping: no org-scoped service account available")
@@ -47,9 +53,13 @@ func TestAccAssetRoutingRuleResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "mondoo_asset_routing_rule.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName: "mondoo_asset_routing_rule.test",
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					return s.RootModule().Resources["mondoo_asset_routing_rule.test"].Primary.Attributes["mrn"], nil
+				},
+				ImportStateVerifyIdentifierAttribute: "mrn",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
 			},
 			// Delete testing automatically occurs in TestCase
 		},
@@ -57,6 +67,9 @@ func TestAccAssetRoutingRuleResource(t *testing.T) {
 }
 
 func TestAccAssetRoutingRuleResourceWithLabel(t *testing.T) {
+	if os.Getenv("RUN_ASSET_ROUTING_TESTS") != "true" {
+		t.Skip("skipping: asset routing tests only run on a single TF version to avoid parallel conflicts")
+	}
 	orgID, err := getOrgId()
 	if err != nil {
 		t.Skip("skipping: no org-scoped service account available")

--- a/internal/provider/asset_routing_table_resource.go
+++ b/internal/provider/asset_routing_table_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) Mondoo, Inc.
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package provider
@@ -27,8 +27,8 @@ type AssetRoutingTableResource struct {
 }
 
 type AssetRoutingTableResourceModel struct {
-	OrgMrn types.String                  `tfsdk:"org_mrn"`
-	Rules  []AssetRoutingTableRuleModel  `tfsdk:"rule"`
+	OrgMrn types.String                 `tfsdk:"org_mrn"`
+	Rules  []AssetRoutingTableRuleModel `tfsdk:"rule"`
 }
 
 type AssetRoutingTableRuleModel struct {

--- a/internal/provider/asset_routing_table_resource.go
+++ b/internal/provider/asset_routing_table_resource.go
@@ -54,22 +54,19 @@ func (r *AssetRoutingTableResource) Schema(_ context.Context, _ resource.SchemaR
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"rule": schema.ListNestedAttribute{
+		},
+		Blocks: map[string]schema.Block{
+			"rule": schema.ListNestedBlock{
 				MarkdownDescription: "Ordered list of routing rules. Priority is determined by position (first = highest priority). A rule with no conditions acts as a catch-all.",
-				Required:            true,
-				NestedObject: schema.NestedAttributeObject{
+				NestedObject: schema.NestedBlockObject{
 					Attributes: map[string]schema.Attribute{
 						"target_space_mrn": schema.StringAttribute{
 							MarkdownDescription: "The MRN of the space where matching assets will be routed.",
 							Required:            true,
 						},
-						"condition": schema.ListNestedAttribute{
-							MarkdownDescription: "Conditions that must all match for this rule to apply (AND logic). If empty, the rule matches all assets (catch-all).",
-							Optional:            true,
-							NestedObject: schema.NestedAttributeObject{
-								Attributes: assetRoutingConditionSchemaAttributes(),
-							},
-						},
+					},
+					Blocks: map[string]schema.Block{
+						"condition": assetRoutingConditionSchemaBlock(),
 					},
 				},
 			},

--- a/internal/provider/asset_routing_table_resource.go
+++ b/internal/provider/asset_routing_table_resource.go
@@ -1,0 +1,221 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	mondoov1 "go.mondoo.com/mondoo-go"
+)
+
+var _ resource.Resource = (*AssetRoutingTableResource)(nil)
+
+func NewAssetRoutingTableResource() resource.Resource {
+	return &AssetRoutingTableResource{}
+}
+
+type AssetRoutingTableResource struct {
+	client *ExtendedGqlClient
+}
+
+type AssetRoutingTableResourceModel struct {
+	OrgMrn types.String                  `tfsdk:"org_mrn"`
+	Rules  []AssetRoutingTableRuleModel  `tfsdk:"rule"`
+}
+
+type AssetRoutingTableRuleModel struct {
+	TargetSpaceMrn types.String                 `tfsdk:"target_space_mrn"`
+	Conditions     []AssetRoutingConditionModel `tfsdk:"condition"`
+}
+
+func (r *AssetRoutingTableResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_asset_routing_table"
+}
+
+func (r *AssetRoutingTableResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: `Manages the asset routing table for a Mondoo organization. This is an **authoritative** resource — it manages the entire routing table and replaces all rules on every apply. Priority is derived from the order of rules in the configuration (first rule = highest priority).
+
+~> **Warning:** Do not use this resource together with ` + "`mondoo_asset_routing_rule`" + ` for the same organization. The table resource replaces all rules atomically, which will overwrite individually managed rules.`,
+
+		Attributes: map[string]schema.Attribute{
+			"org_mrn": schema.StringAttribute{
+				MarkdownDescription: "The Mondoo Resource Name (MRN) of the organization.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"rule": schema.ListNestedAttribute{
+				MarkdownDescription: "Ordered list of routing rules. Priority is determined by position (first = highest priority). A rule with no conditions acts as a catch-all.",
+				Required:            true,
+				NestedObject: schema.NestedAttributeObject{
+					Attributes: map[string]schema.Attribute{
+						"target_space_mrn": schema.StringAttribute{
+							MarkdownDescription: "The MRN of the space where matching assets will be routed.",
+							Required:            true,
+						},
+						"condition": schema.ListNestedAttribute{
+							MarkdownDescription: "Conditions that must all match for this rule to apply (AND logic). If empty, the rule matches all assets (catch-all).",
+							Optional:            true,
+							NestedObject: schema.NestedAttributeObject{
+								Attributes: assetRoutingConditionSchemaAttributes(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *AssetRoutingTableResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*ExtendedGqlClient)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *ExtendedGqlClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+	r.client = client
+}
+
+func (r *AssetRoutingTableResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data AssetRoutingTableResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := tableInputFromModel(data)
+	tflog.Debug(ctx, "creating asset routing table", map[string]interface{}{
+		"orgMrn": data.OrgMrn.ValueString(),
+		"rules":  len(data.Rules),
+	})
+
+	result, err := r.client.SetAssetRoutingTable(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to create asset routing table", err.Error())
+		return
+	}
+
+	data.Rules = tableRulesFromPayload(result.Rules)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AssetRoutingTableResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data AssetRoutingTableResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	orgMrn := data.OrgMrn.ValueString()
+	result, err := r.client.GetAssetRoutingTable(ctx, orgMrn)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to read asset routing table", err.Error())
+		return
+	}
+
+	data.OrgMrn = types.StringValue(result.OrgMrn)
+	data.Rules = tableRulesFromPayload(result.Rules)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AssetRoutingTableResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data AssetRoutingTableResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	input := tableInputFromModel(data)
+	tflog.Debug(ctx, "updating asset routing table", map[string]interface{}{
+		"orgMrn": data.OrgMrn.ValueString(),
+		"rules":  len(data.Rules),
+	})
+
+	result, err := r.client.SetAssetRoutingTable(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to update asset routing table", err.Error())
+		return
+	}
+
+	data.Rules = tableRulesFromPayload(result.Rules)
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *AssetRoutingTableResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data AssetRoutingTableResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	orgMrn := data.OrgMrn.ValueString()
+	tflog.Debug(ctx, "clearing asset routing table", map[string]interface{}{
+		"orgMrn": orgMrn,
+	})
+
+	err := r.client.ClearAssetRoutingTable(ctx, orgMrn)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to clear asset routing table", err.Error())
+	}
+}
+
+func (r *AssetRoutingTableResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	orgMrn := req.ID
+
+	result, err := r.client.GetAssetRoutingTable(ctx, orgMrn)
+	if err != nil {
+		resp.Diagnostics.AddError("Failed to import asset routing table", err.Error())
+		return
+	}
+
+	data := AssetRoutingTableResourceModel{
+		OrgMrn: types.StringValue(result.OrgMrn),
+		Rules:  tableRulesFromPayload(result.Rules),
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// tableInputFromModel converts the Terraform model to a GraphQL SetAssetRoutingTableInput.
+func tableInputFromModel(data AssetRoutingTableResourceModel) SetAssetRoutingTableInput {
+	rules := make([]AssetRoutingRuleInput, len(data.Rules))
+	for i, rule := range data.Rules {
+		rules[i] = AssetRoutingRuleInput{
+			TargetSpaceMrn: mondoov1.String(rule.TargetSpaceMrn.ValueString()),
+			Conditions:     conditionsFromModel(rule.Conditions),
+		}
+	}
+	return SetAssetRoutingTableInput{
+		OrgMrn: mondoov1.String(data.OrgMrn.ValueString()),
+		Rules:  rules,
+	}
+}
+
+// tableRulesFromPayload converts GraphQL rule payloads to Terraform models.
+// Rules are expected to come back in priority order from the API.
+func tableRulesFromPayload(rules []AssetRoutingRulePayload) []AssetRoutingTableRuleModel {
+	result := make([]AssetRoutingTableRuleModel, len(rules))
+	for i, rule := range rules {
+		result[i] = AssetRoutingTableRuleModel{
+			TargetSpaceMrn: types.StringValue(rule.TargetSpaceMrn),
+			Conditions:     conditionsToModel(rule.Conditions),
+		}
+	}
+	return result
+}

--- a/internal/provider/asset_routing_table_resource.go
+++ b/internal/provider/asset_routing_table_resource.go
@@ -123,6 +123,10 @@ func (r *AssetRoutingTableResource) Read(ctx context.Context, req resource.ReadR
 	orgMrn := data.OrgMrn.ValueString()
 	result, err := r.client.GetAssetRoutingTable(ctx, orgMrn)
 	if err != nil {
+		if isNotFoundError(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError("Failed to read asset routing table", err.Error())
 		return
 	}

--- a/internal/provider/asset_routing_table_resource_test.go
+++ b/internal/provider/asset_routing_table_resource_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Mondoo, Inc.
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package provider

--- a/internal/provider/asset_routing_table_resource_test.go
+++ b/internal/provider/asset_routing_table_resource_test.go
@@ -5,12 +5,16 @@ package provider
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
 func TestAccAssetRoutingTableResource(t *testing.T) {
+	if os.Getenv("RUN_ASSET_ROUTING_TESTS") != "true" {
+		t.Skip("skipping: asset routing tests only run on a single TF version to avoid parallel conflicts")
+	}
 	orgID, err := getOrgId()
 	if err != nil {
 		t.Skip("skipping: no org-scoped service account available")
@@ -47,10 +51,11 @@ func TestAccAssetRoutingTableResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "mondoo_asset_routing_table.test",
-				ImportState:       true,
-				ImportStateId:     orgMrn,
-				ImportStateVerify: true,
+				ResourceName:                         "mondoo_asset_routing_table.test",
+				ImportState:                          true,
+				ImportStateId:                        orgMrn,
+				ImportStateVerifyIdentifierAttribute: "org_mrn",
+				ImportStateVerify:                    true,
 			},
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/asset_routing_table_resource_test.go
+++ b/internal/provider/asset_routing_table_resource_test.go
@@ -1,0 +1,98 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccAssetRoutingTableResource(t *testing.T) {
+	orgID, err := getOrgId()
+	if err != nil {
+		t.Skip("skipping: no org-scoped service account available")
+	}
+	orgMrn := orgPrefix + orgID
+	targetSpaceMrn := accSpace.MRN()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with a single rule
+			{
+				Config: testAccAssetRoutingTableConfig(orgMrn, targetSpaceMrn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "org_mrn", orgMrn),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "rule.#", "1"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "rule.0.target_space_mrn", targetSpaceMrn),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "rule.0.condition.#", "1"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "rule.0.condition.0.field", "PLATFORM"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "rule.0.condition.0.operator", "EQUAL"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "rule.0.condition.0.values.0", "ubuntu"),
+				),
+			},
+			// Update to two rules (add a catch-all)
+			{
+				Config: testAccAssetRoutingTableConfigWithCatchAll(orgMrn, targetSpaceMrn),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "rule.#", "2"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "rule.0.condition.#", "1"),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "rule.1.target_space_mrn", targetSpaceMrn),
+					resource.TestCheckResourceAttr("mondoo_asset_routing_table.test", "rule.1.condition.#", "0"),
+				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "mondoo_asset_routing_table.test",
+				ImportState:       true,
+				ImportStateId:     orgMrn,
+				ImportStateVerify: true,
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccAssetRoutingTableConfig(orgMrn, targetSpaceMrn string) string {
+	return fmt.Sprintf(`
+resource "mondoo_asset_routing_table" "test" {
+  org_mrn = %[1]q
+
+  rule {
+    target_space_mrn = %[2]q
+
+    condition {
+      field    = "PLATFORM"
+      operator = "EQUAL"
+      values   = ["ubuntu"]
+    }
+  }
+}
+`, orgMrn, targetSpaceMrn)
+}
+
+func testAccAssetRoutingTableConfigWithCatchAll(orgMrn, targetSpaceMrn string) string {
+	return fmt.Sprintf(`
+resource "mondoo_asset_routing_table" "test" {
+  org_mrn = %[1]q
+
+  rule {
+    target_space_mrn = %[2]q
+
+    condition {
+      field    = "PLATFORM"
+      operator = "EQUAL"
+      values   = ["ubuntu"]
+    }
+  }
+
+  rule {
+    target_space_mrn = %[2]q
+  }
+}
+`, orgMrn, targetSpaceMrn)
+}

--- a/internal/provider/gql.go
+++ b/internal/provider/gql.go
@@ -1724,3 +1724,161 @@ func (c *ExtendedGqlClient) GetException(ctx context.Context, scopeMrn string, i
 	})
 	return &listExceptionGroups.ListExceptionGroups.Edges[0].Node, nil
 }
+
+// Asset routing types
+
+type AssetRoutingConditionField string
+
+const (
+	AssetRoutingConditionFieldHostname AssetRoutingConditionField = "HOSTNAME"
+	AssetRoutingConditionFieldPlatform AssetRoutingConditionField = "PLATFORM"
+	AssetRoutingConditionFieldLabel    AssetRoutingConditionField = "LABEL"
+)
+
+type AssetRoutingConditionOperator string
+
+const (
+	AssetRoutingConditionOperatorEqual    AssetRoutingConditionOperator = "EQUAL"
+	AssetRoutingConditionOperatorNotEqual AssetRoutingConditionOperator = "NOT_EQUAL"
+	AssetRoutingConditionOperatorContains AssetRoutingConditionOperator = "CONTAINS"
+	AssetRoutingConditionOperatorMatches  AssetRoutingConditionOperator = "MATCHES"
+)
+
+// Input types for asset routing mutations
+
+type AssetRoutingConditionInput struct {
+	Field    AssetRoutingConditionField    `json:"field"`
+	Operator AssetRoutingConditionOperator `json:"operator"`
+	Values   []mondoov1.String             `json:"values"`
+	Key      *mondoov1.String              `json:"key,omitempty"`
+}
+
+type AssetRoutingRuleInput struct {
+	TargetSpaceMrn mondoov1.String              `json:"targetSpaceMrn"`
+	Conditions     []AssetRoutingConditionInput `json:"conditions"`
+}
+
+type SetAssetRoutingTableInput struct {
+	OrgMrn mondoov1.String         `json:"orgMrn"`
+	Rules  []AssetRoutingRuleInput `json:"rules"`
+}
+
+type CreateAssetRoutingRuleInput struct {
+	OrgMrn         mondoov1.String              `json:"orgMrn"`
+	TargetSpaceMrn mondoov1.String              `json:"targetSpaceMrn"`
+	Priority       mondoov1.Int                 `json:"priority"`
+	Conditions     []AssetRoutingConditionInput `json:"conditions"`
+}
+
+type UpdateAssetRoutingRuleInput struct {
+	RuleMrn        mondoov1.String              `json:"ruleMrn"`
+	TargetSpaceMrn mondoov1.String              `json:"targetSpaceMrn"`
+	Priority       mondoov1.Int                 `json:"priority"`
+	Conditions     []AssetRoutingConditionInput `json:"conditions"`
+}
+
+// Payload types for asset routing responses
+
+type AssetRoutingConditionPayload struct {
+	Field    string   `json:"field" graphql:"field"`
+	Operator string   `json:"operator" graphql:"operator"`
+	Values   []string `json:"values" graphql:"values"`
+	Key      string   `json:"key" graphql:"key"`
+}
+
+type AssetRoutingRulePayload struct {
+	Mrn            string                         `json:"mrn" graphql:"mrn"`
+	TargetSpaceMrn string                         `json:"targetSpaceMrn" graphql:"targetSpaceMrn"`
+	Priority       int                            `json:"priority" graphql:"priority"`
+	Conditions     []AssetRoutingConditionPayload `json:"conditions" graphql:"conditions"`
+}
+
+type AssetRoutingTablePayload struct {
+	OrgMrn string                    `json:"orgMrn" graphql:"orgMrn"`
+	Rules  []AssetRoutingRulePayload `json:"rules" graphql:"rules"`
+}
+
+// Asset routing client methods
+
+func (c *ExtendedGqlClient) SetAssetRoutingTable(ctx context.Context, input SetAssetRoutingTableInput) (AssetRoutingTablePayload, error) {
+	var mutation struct {
+		SetAssetRoutingTable AssetRoutingTablePayload `graphql:"setAssetRoutingTable(input: $input)"`
+	}
+
+	tflog.Trace(ctx, "SetAssetRoutingTableInput", map[string]interface{}{
+		"input": fmt.Sprintf("%+v", input),
+	})
+
+	err := c.Mutate(ctx, &mutation, input, nil)
+	return mutation.SetAssetRoutingTable, err
+}
+
+func (c *ExtendedGqlClient) GetAssetRoutingTable(ctx context.Context, orgMrn string) (AssetRoutingTablePayload, error) {
+	var q struct {
+		AssetRoutingTable AssetRoutingTablePayload `graphql:"assetRoutingTable(orgMrn: $orgMrn)"`
+	}
+	variables := map[string]interface{}{
+		"orgMrn": mondoov1.String(orgMrn),
+	}
+
+	err := c.Query(ctx, &q, variables)
+	return q.AssetRoutingTable, err
+}
+
+func (c *ExtendedGqlClient) ClearAssetRoutingTable(ctx context.Context, orgMrn string) error {
+	var mutation struct {
+		ClearAssetRoutingTable mondoov1.Boolean `graphql:"clearAssetRoutingTable(orgMrn: $orgMrn)"`
+	}
+	variables := map[string]interface{}{
+		"orgMrn": mondoov1.String(orgMrn),
+	}
+	return c.Mutate(ctx, &mutation, nil, variables)
+}
+
+func (c *ExtendedGqlClient) CreateAssetRoutingRule(ctx context.Context, input CreateAssetRoutingRuleInput) (AssetRoutingRulePayload, error) {
+	var mutation struct {
+		CreateAssetRoutingRule AssetRoutingRulePayload `graphql:"createAssetRoutingRule(input: $input)"`
+	}
+
+	tflog.Trace(ctx, "CreateAssetRoutingRuleInput", map[string]interface{}{
+		"input": fmt.Sprintf("%+v", input),
+	})
+
+	err := c.Mutate(ctx, &mutation, input, nil)
+	return mutation.CreateAssetRoutingRule, err
+}
+
+func (c *ExtendedGqlClient) GetAssetRoutingRule(ctx context.Context, ruleMrn string) (AssetRoutingRulePayload, error) {
+	var q struct {
+		AssetRoutingRule AssetRoutingRulePayload `graphql:"assetRoutingRule(ruleMrn: $ruleMrn)"`
+	}
+	variables := map[string]interface{}{
+		"ruleMrn": mondoov1.String(ruleMrn),
+	}
+
+	err := c.Query(ctx, &q, variables)
+	return q.AssetRoutingRule, err
+}
+
+func (c *ExtendedGqlClient) UpdateAssetRoutingRule(ctx context.Context, input UpdateAssetRoutingRuleInput) (AssetRoutingRulePayload, error) {
+	var mutation struct {
+		UpdateAssetRoutingRule AssetRoutingRulePayload `graphql:"updateAssetRoutingRule(input: $input)"`
+	}
+
+	tflog.Trace(ctx, "UpdateAssetRoutingRuleInput", map[string]interface{}{
+		"input": fmt.Sprintf("%+v", input),
+	})
+
+	err := c.Mutate(ctx, &mutation, input, nil)
+	return mutation.UpdateAssetRoutingRule, err
+}
+
+func (c *ExtendedGqlClient) DeleteAssetRoutingRule(ctx context.Context, ruleMrn string) error {
+	var mutation struct {
+		DeleteAssetRoutingRule mondoov1.Boolean `graphql:"deleteAssetRoutingRule(ruleMrn: $ruleMrn)"`
+	}
+	variables := map[string]interface{}{
+		"ruleMrn": mondoov1.String(ruleMrn),
+	}
+	return c.Mutate(ctx, &mutation, nil, variables)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -230,6 +230,8 @@ func (p *MondooProvider) Resources(_ context.Context) []func() resource.Resource
 		NewMondooExportGSCBucketResource,
 		NewMondooExportBigQueryResource,
 		NewIntegrationMsIntuneResource,
+		NewAssetRoutingTableResource,
+		NewAssetRoutingRuleResource,
 	}...)
 }
 


### PR DESCRIPTION
## Summary

Adds two new Terraform resources for managing org-level asset routing 

- **`mondoo_asset_routing_table`** (authoritative) — manages the entire routing table for an org, replacing all rules atomically on apply. Priority is derived from rule order in config.
- **`mondoo_asset_routing_rule`** (non-authoritative) — manages individual routing rules independently with explicit priority. Ideal for multi-team setups where each team manages their own rules.

### Example: Authoritative (full table)

```hcl
resource "mondoo_asset_routing_table" "main" {
  org_mrn = mondoo_organization.example.mrn

  rule {
    target_space_mrn = mondoo_space.linux.mrn
    condition {
      field    = "PLATFORM"
      operator = "EQUAL"
      values   = ["ubuntu", "debian", "rhel"]
    }
  }

  rule {
    target_space_mrn = mondoo_space.catchall.mrn
  }
}
```

### Example: Non-authoritative (individual rules)

```hcl
resource "mondoo_asset_routing_rule" "team_a" {
  org_mrn          = mondoo_organization.example.mrn
  target_space_mrn = mondoo_space.team_a.mrn
  priority         = 10

  condition {
    field    = "LABEL"
    operator = "EQUAL"
    key      = "team"
    values   = ["team-a"]
  }
}
```

### Condition fields & operators

- **Fields:** `HOSTNAME`, `PLATFORM`, `LABEL` (with optional `key`)
- **Operators:** `EQUAL`, `NOT_EQUAL`, `CONTAINS`, `MATCHES` (glob)
- Conditions within a rule use AND logic; values within a condition use OR logic

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Acceptance tests: `TF_ACC=1 go test ./internal/provider/ -run TestAccAssetRouting -v`
- [ ] Manual: `terraform plan` with example configs
- [ ] Generate docs from main checkout (worktree name breaks tfplugindocs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)