### PR TITLE
Add mondoo_team_member resource

### DIFF
--- a/examples/resources/mondoo_team_member/main.tf
+++ b/examples/resources/mondoo_team_member/main.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    mondoo = {
+      source  = "mondoohq/mondoo"
+      version = ">= 0.35.7"
+    }
+  }
+}

--- a/examples/resources/mondoo_team_member/resource.tf
+++ b/examples/resources/mondoo_team_member/resource.tf
@@ -1,0 +1,15 @@
+# Add a member to a team by email
+resource "mondoo_team" "example" {
+  name      = "security-team"
+  scope_mrn = mondoo_organization.example.mrn
+}
+
+resource "mondoo_team_member" "alice" {
+  team_mrn = mondoo_team.example.mrn
+  email    = "alice@example.com"
+}
+
+resource "mondoo_team_member" "bob" {
+  team_mrn = mondoo_team.example.mrn
+  email    = "bob@example.com"
+}

--- a/examples/resources/mondoo_team_member/resource.tf
+++ b/examples/resources/mondoo_team_member/resource.tf
@@ -1,15 +1,27 @@
+variable "org_id" {
+  description = "The ID of the organization in which to create the space and teams"
+  type        = string
+}
+
+provider "mondoo" {}
+
+data "mondoo_organization" "example" {
+  id = var.org_id
+}
+
 # Add a member to a team by email
 resource "mondoo_team" "example" {
   name      = "security-team"
-  scope_mrn = mondoo_organization.example.mrn
+  scope_mrn = data.mondoo_organization.example.mrn
 }
 
 resource "mondoo_team_member" "alice" {
   team_mrn = mondoo_team.example.mrn
-  email    = "alice@example.com"
+  identity = "alice@example.com"
 }
 
 resource "mondoo_team_member" "bob" {
   team_mrn = mondoo_team.example.mrn
-  email    = "bob@example.com"
+  identity = "bob@example.com"
 }
+

--- a/internal/provider/gql.go
+++ b/internal/provider/gql.go
@@ -1374,6 +1374,79 @@ func (c *ExtendedGqlClient) RemoveTeamExternalGroupMapping(ctx context.Context, 
 	return c.Mutate(ctx, &mutation, mondoov1.String(mrn), nil)
 }
 
+// Team Member types and methods
+
+type AddTeamMemberInput struct {
+	TeamMrn   mondoov1.String  `json:"teamMrn"`
+	MemberMrn *mondoov1.String `json:"memberMrn,omitempty"`
+	Email     *mondoov1.String `json:"email,omitempty"`
+}
+
+type AddTeamMemberPayload struct {
+	CreatedPending mondoov1.Boolean `json:"createdPending"`
+	MemberMrn      *mondoov1.String `json:"memberMrn"`
+}
+
+type RemoveTeamMemberInput struct {
+	TeamMrn   mondoov1.String  `json:"teamMrn"`
+	MemberMrn *mondoov1.String `json:"memberMrn,omitempty"`
+	Email     *mondoov1.String `json:"email,omitempty"`
+}
+
+type TeamMemberPayload struct {
+	Mrn   *mondoov1.String `json:"mrn"`
+	Email mondoov1.String  `json:"email"`
+	Name  *mondoov1.String `json:"name"`
+}
+
+func (c *ExtendedGqlClient) AddTeamMember(ctx context.Context, input AddTeamMemberInput) (AddTeamMemberPayload, error) {
+	var mutation struct {
+		AddTeamMember AddTeamMemberPayload `graphql:"addTeamMember(input: $input)"`
+	}
+
+	tflog.Trace(ctx, "AddTeamMemberInput", map[string]interface{}{
+		"input": fmt.Sprintf("%+v", input),
+	})
+
+	err := c.Mutate(ctx, &mutation, input, nil)
+	return mutation.AddTeamMember, err
+}
+
+func (c *ExtendedGqlClient) GetTeamMember(ctx context.Context, teamMrn string, email string) (*TeamMemberPayload, error) {
+	var query struct {
+		TeamMember *TeamMemberPayload `graphql:"teamMember(teamMrn: $teamMrn, email: $email)"`
+	}
+	variables := map[string]interface{}{
+		"teamMrn": mondoov1.String(teamMrn),
+		"email":   mondoov1.String(email),
+	}
+
+	tflog.Trace(ctx, "GetTeamMember", map[string]interface{}{
+		"teamMrn": teamMrn,
+		"email":   email,
+	})
+
+	err := c.Query(ctx, &query, variables)
+	if err != nil {
+		return nil, err
+	}
+	return query.TeamMember, nil
+}
+
+func (c *ExtendedGqlClient) RemoveTeamMember(ctx context.Context, input RemoveTeamMemberInput) error {
+	var mutation struct {
+		RemoveTeamMember struct {
+			MemberMrn *mondoov1.String `json:"memberMrn"`
+		} `graphql:"removeTeamMember(input: $input)"`
+	}
+
+	tflog.Trace(ctx, "RemoveTeamMemberInput", map[string]interface{}{
+		"input": fmt.Sprintf("%+v", input),
+	})
+
+	return c.Mutate(ctx, &mutation, input, nil)
+}
+
 type RoleInput struct {
 	Mrn mondoov1.String `json:"mrn"`
 }

--- a/internal/provider/gql.go
+++ b/internal/provider/gql.go
@@ -1377,9 +1377,8 @@ func (c *ExtendedGqlClient) RemoveTeamExternalGroupMapping(ctx context.Context, 
 // Team Member types and methods
 
 type AddTeamMemberInput struct {
-	TeamMrn   mondoov1.String  `json:"teamMrn"`
-	MemberMrn *mondoov1.String `json:"memberMrn,omitempty"`
-	Email     *mondoov1.String `json:"email,omitempty"`
+	TeamMrn  mondoov1.String  `json:"teamMrn"`
+	Identity *mondoov1.String `json:"identity,omitempty"`
 }
 
 type AddTeamMemberPayload struct {
@@ -1388,9 +1387,8 @@ type AddTeamMemberPayload struct {
 }
 
 type RemoveTeamMemberInput struct {
-	TeamMrn   mondoov1.String  `json:"teamMrn"`
-	MemberMrn *mondoov1.String `json:"memberMrn,omitempty"`
-	Email     *mondoov1.String `json:"email,omitempty"`
+	TeamMrn  mondoov1.String  `json:"teamMrn"`
+	Identity *mondoov1.String `json:"identity,omitempty"`
 }
 
 type TeamMemberPayload struct {
@@ -1412,18 +1410,18 @@ func (c *ExtendedGqlClient) AddTeamMember(ctx context.Context, input AddTeamMemb
 	return mutation.AddTeamMember, err
 }
 
-func (c *ExtendedGqlClient) GetTeamMember(ctx context.Context, teamMrn string, email string) (*TeamMemberPayload, error) {
+func (c *ExtendedGqlClient) GetTeamMember(ctx context.Context, teamMrn string, identity string) (*TeamMemberPayload, error) {
 	var query struct {
-		TeamMember *TeamMemberPayload `graphql:"teamMember(teamMrn: $teamMrn, email: $email)"`
+		TeamMember *TeamMemberPayload `graphql:"teamMember(teamMrn: $teamMrn, identity: $identity)"`
 	}
 	variables := map[string]interface{}{
-		"teamMrn": mondoov1.String(teamMrn),
-		"email":   mondoov1.String(email),
+		"teamMrn":  mondoov1.String(teamMrn),
+		"identity": mondoov1.String(identity),
 	}
 
 	tflog.Trace(ctx, "GetTeamMember", map[string]interface{}{
-		"teamMrn": teamMrn,
-		"email":   email,
+		"teamMrn":  teamMrn,
+		"identity": identity,
 	})
 
 	err := c.Query(ctx, &query, variables)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -223,6 +223,7 @@ func (p *MondooProvider) Resources(_ context.Context) []func() resource.Resource
 		NewTeamResource,
 		NewTeamExternalGroupMappingResource,
 		NewResourceContactsResource,
+		NewTeamMemberResource,
 		NewIAMBindingResource,
 		NewExportGSCBucketResource,
 		NewExportS3BucketResource,

--- a/internal/provider/team_member_resource.go
+++ b/internal/provider/team_member_resource.go
@@ -30,7 +30,7 @@ type TeamMemberResource struct {
 // TeamMemberResourceModel describes the resource data model.
 type TeamMemberResourceModel struct {
 	TeamMrn   types.String `tfsdk:"team_mrn"`
-	Email     types.String `tfsdk:"email"`
+	Identity  types.String `tfsdk:"identity"`
 	MemberMrn types.String `tfsdk:"member_mrn"`
 }
 
@@ -40,7 +40,7 @@ func (r *TeamMemberResource) Metadata(ctx context.Context, req resource.Metadata
 
 func (r *TeamMemberResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: `This resource manages team membership in Mondoo. It allows adding users to teams by email address. If the user does not yet have a Mondoo account, a pending membership is created.
+		MarkdownDescription: `This resource manages team membership in Mondoo. It allows adding users to teams by email address or MRN. If the user does not yet have a Mondoo account, a pending membership is created.
 
 **Example usage:**
 
@@ -52,7 +52,7 @@ resource "mondoo_team" "example" {
 
 resource "mondoo_team_member" "alice" {
   team_mrn = mondoo_team.example.mrn
-  email    = "alice@example.com"
+  identity = "alice@example.com"
 }
 ` + "```",
 
@@ -64,8 +64,8 @@ resource "mondoo_team_member" "alice" {
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
-			"email": schema.StringAttribute{
-				MarkdownDescription: "Email address of the user to add to the team.",
+			"identity": schema.StringAttribute{
+				MarkdownDescription: "Email address or MRN of the user to add to the team.",
 				Required:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
@@ -109,10 +109,10 @@ func (r *TeamMemberResource) Create(ctx context.Context, req resource.CreateRequ
 		return
 	}
 
-	email := mondoov1.String(data.Email.ValueString())
+	identity := mondoov1.String(data.Identity.ValueString())
 	input := AddTeamMemberInput{
-		TeamMrn: mondoov1.String(data.TeamMrn.ValueString()),
-		Email:   &email,
+		TeamMrn:  mondoov1.String(data.TeamMrn.ValueString()),
+		Identity: &identity,
 	}
 
 	payload, err := r.client.AddTeamMember(ctx, input)
@@ -143,7 +143,7 @@ func (r *TeamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	// Get the team member from the API
-	member, err := r.client.GetTeamMember(ctx, data.TeamMrn.ValueString(), data.Email.ValueString())
+	member, err := r.client.GetTeamMember(ctx, data.TeamMrn.ValueString(), data.Identity.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team member, got error: %s", err))
 		return
@@ -156,7 +156,6 @@ func (r *TeamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 	}
 
 	// Map response back to schema
-	data.Email = types.StringValue(string(member.Email))
 	if member.Mrn != nil {
 		data.MemberMrn = types.StringValue(string(*member.Mrn))
 	} else {
@@ -168,11 +167,11 @@ func (r *TeamMemberResource) Read(ctx context.Context, req resource.ReadRequest,
 }
 
 func (r *TeamMemberResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// Team members are immutable - both team_mrn and email require replacement
+	// Team members are immutable - both team_mrn and identity require replacement
 	// This method should never be called due to RequiresReplace plan modifiers
 	resp.Diagnostics.AddError(
 		"Unexpected Update Call",
-		"Team members cannot be updated. Both team_mrn and email changes require replacement.",
+		"Team members cannot be updated. Both team_mrn and identity changes require replacement.",
 	)
 }
 
@@ -186,10 +185,10 @@ func (r *TeamMemberResource) Delete(ctx context.Context, req resource.DeleteRequ
 		return
 	}
 
-	email := mondoov1.String(data.Email.ValueString())
+	identity := mondoov1.String(data.Identity.ValueString())
 	input := RemoveTeamMemberInput{
-		TeamMrn: mondoov1.String(data.TeamMrn.ValueString()),
-		Email:   &email,
+		TeamMrn:  mondoov1.String(data.TeamMrn.ValueString()),
+		Identity: &identity,
 	}
 
 	err := r.client.RemoveTeamMember(ctx, input)

--- a/internal/provider/team_member_resource.go
+++ b/internal/provider/team_member_resource.go
@@ -6,7 +6,9 @@ package provider
 import (
 	"context"
 	"fmt"
+	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
@@ -17,6 +19,7 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = &TeamMemberResource{}
+var _ resource.ResourceWithImportState = &TeamMemberResource{}
 
 func NewTeamMemberResource() resource.Resource {
 	return &TeamMemberResource{}
@@ -199,4 +202,19 @@ func (r *TeamMemberResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to remove team member, got error: %s", err))
 		return
 	}
+}
+
+func (r *TeamMemberResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	// Import ID format: <team_mrn>:<identity>
+	parts := strings.SplitN(req.ID, ":", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Invalid Import ID",
+			fmt.Sprintf("Expected import ID format: <team_mrn>:<identity>, got: %s", req.ID),
+		)
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("team_mrn"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("identity"), parts[1])...)
 }

--- a/internal/provider/team_member_resource.go
+++ b/internal/provider/team_member_resource.go
@@ -1,0 +1,200 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	mondoov1 "go.mondoo.com/mondoo-go"
+)
+
+// Ensure provider defined types fully satisfy framework interfaces.
+var _ resource.Resource = &TeamMemberResource{}
+
+func NewTeamMemberResource() resource.Resource {
+	return &TeamMemberResource{}
+}
+
+// TeamMemberResource defines the resource implementation.
+type TeamMemberResource struct {
+	client *ExtendedGqlClient
+}
+
+// TeamMemberResourceModel describes the resource data model.
+type TeamMemberResourceModel struct {
+	TeamMrn   types.String `tfsdk:"team_mrn"`
+	Email     types.String `tfsdk:"email"`
+	MemberMrn types.String `tfsdk:"member_mrn"`
+}
+
+func (r *TeamMemberResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_team_member"
+}
+
+func (r *TeamMemberResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: `This resource manages team membership in Mondoo. It allows adding users to teams by email address. If the user does not yet have a Mondoo account, a pending membership is created.
+
+**Example usage:**
+
+` + "```hcl" + `
+resource "mondoo_team" "example" {
+  name      = "security-team"
+  scope_mrn = mondoo_organization.example.mrn
+}
+
+resource "mondoo_team_member" "alice" {
+  team_mrn = mondoo_team.example.mrn
+  email    = "alice@example.com"
+}
+` + "```",
+
+		Attributes: map[string]schema.Attribute{
+			"team_mrn": schema.StringAttribute{
+				MarkdownDescription: "MRN of the team to add the member to.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"email": schema.StringAttribute{
+				MarkdownDescription: "Email address of the user to add to the team.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"member_mrn": schema.StringAttribute{
+				MarkdownDescription: "MRN of the member. Empty if the user has not yet registered.",
+				Computed:            true,
+			},
+		},
+	}
+}
+
+func (r *TeamMemberResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*ExtendedGqlClient)
+
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected *ExtendedGqlClient, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+
+		return
+	}
+
+	r.client = client
+}
+
+func (r *TeamMemberResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data TeamMemberResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	email := mondoov1.String(data.Email.ValueString())
+	input := AddTeamMemberInput{
+		TeamMrn: mondoov1.String(data.TeamMrn.ValueString()),
+		Email:   &email,
+	}
+
+	payload, err := r.client.AddTeamMember(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to add team member, got error: %s", err))
+		return
+	}
+
+	// Map response back to schema
+	if payload.MemberMrn != nil {
+		data.MemberMrn = types.StringValue(string(*payload.MemberMrn))
+	} else {
+		data.MemberMrn = types.StringValue("")
+	}
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *TeamMemberResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data TeamMemberResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get the team member from the API
+	member, err := r.client.GetTeamMember(ctx, data.TeamMrn.ValueString(), data.Email.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read team member, got error: %s", err))
+		return
+	}
+
+	// If the member is not found, remove from state (drift detection)
+	if member == nil {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	// Map response back to schema
+	data.Email = types.StringValue(string(member.Email))
+	if member.Mrn != nil {
+		data.MemberMrn = types.StringValue(string(*member.Mrn))
+	} else {
+		data.MemberMrn = types.StringValue("")
+	}
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *TeamMemberResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Team members are immutable - both team_mrn and email require replacement
+	// This method should never be called due to RequiresReplace plan modifiers
+	resp.Diagnostics.AddError(
+		"Unexpected Update Call",
+		"Team members cannot be updated. Both team_mrn and email changes require replacement.",
+	)
+}
+
+func (r *TeamMemberResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data TeamMemberResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	email := mondoov1.String(data.Email.ValueString())
+	input := RemoveTeamMemberInput{
+		TeamMrn: mondoov1.String(data.TeamMrn.ValueString()),
+		Email:   &email,
+	}
+
+	err := r.client.RemoveTeamMember(ctx, input)
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to remove team member, got error: %s", err))
+		return
+	}
+}

--- a/internal/provider/team_member_resource.go
+++ b/internal/provider/team_member_resource.go
@@ -1,4 +1,4 @@
-// Copyright (c) Mondoo, Inc.
+// Copyright Mondoo, Inc. 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package provider

--- a/internal/provider/team_member_resource.go
+++ b/internal/provider/team_member_resource.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package provider

--- a/internal/provider/team_member_resource.go
+++ b/internal/provider/team_member_resource.go
@@ -74,6 +74,9 @@ resource "mondoo_team_member" "alice" {
 			"member_mrn": schema.StringAttribute{
 				MarkdownDescription: "MRN of the member. Empty if the user has not yet registered.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}

--- a/internal/provider/team_member_resource_test.go
+++ b/internal/provider/team_member_resource_test.go
@@ -21,7 +21,6 @@ func TestAccTeamMemberResource(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("mondoo_team_member.test", "identity", "alice@example.com"),
 					resource.TestCheckResourceAttrSet("mondoo_team_member.test", "team_mrn"),
-					resource.TestCheckResourceAttrSet("mondoo_team_member.test", "member_mrn"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase

--- a/internal/provider/team_member_resource_test.go
+++ b/internal/provider/team_member_resource_test.go
@@ -19,7 +19,7 @@ func TestAccTeamMemberResource(t *testing.T) {
 			{
 				Config: testAccTeamMemberResourceConfig("test-member-team", "alice@example.com"),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("mondoo_team_member.test", "email", "alice@example.com"),
+					resource.TestCheckResourceAttr("mondoo_team_member.test", "identity", "alice@example.com"),
 					resource.TestCheckResourceAttrSet("mondoo_team_member.test", "team_mrn"),
 					resource.TestCheckResourceAttrSet("mondoo_team_member.test", "member_mrn"),
 				),
@@ -29,7 +29,7 @@ func TestAccTeamMemberResource(t *testing.T) {
 	})
 }
 
-func testAccTeamMemberResourceConfig(teamName, email string) string {
+func testAccTeamMemberResourceConfig(teamName, identity string) string {
 	return fmt.Sprintf(`
 resource "mondoo_team" "test" {
   name      = %[1]q
@@ -38,7 +38,7 @@ resource "mondoo_team" "test" {
 
 resource "mondoo_team_member" "test" {
   team_mrn = mondoo_team.test.mrn
-  email    = %[2]q
+  identity = %[2]q
 }
-`, teamName, email, accSpace.MRN())
+`, teamName, identity, accSpace.MRN())
 }

--- a/internal/provider/team_member_resource_test.go
+++ b/internal/provider/team_member_resource_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) Mondoo, Inc.
+// Copyright Mondoo, Inc. 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package provider

--- a/internal/provider/team_member_resource_test.go
+++ b/internal/provider/team_member_resource_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )
 
 func TestAccTeamMemberResource(t *testing.T) {
@@ -22,6 +23,19 @@ func TestAccTeamMemberResource(t *testing.T) {
 					resource.TestCheckResourceAttr("mondoo_team_member.test", "identity", "alice@example.com"),
 					resource.TestCheckResourceAttrSet("mondoo_team_member.test", "team_mrn"),
 				),
+			},
+			// ImportState testing
+			{
+				ResourceName:      "mondoo_team_member.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateIdFunc: func(s *terraform.State) (string, error) {
+					rs, ok := s.RootModule().Resources["mondoo_team_member.test"]
+					if !ok {
+						return "", fmt.Errorf("resource not found: mondoo_team_member.test")
+					}
+					return rs.Primary.Attributes["team_mrn"] + ":" + rs.Primary.Attributes["identity"], nil
+				},
 			},
 			// Delete testing automatically occurs in TestCase
 		},

--- a/internal/provider/team_member_resource_test.go
+++ b/internal/provider/team_member_resource_test.go
@@ -1,4 +1,4 @@
-// Copyright Mondoo, Inc. 2026
+// Copyright Mondoo, Inc. 2024, 2026
 // SPDX-License-Identifier: BUSL-1.1
 
 package provider

--- a/internal/provider/team_member_resource_test.go
+++ b/internal/provider/team_member_resource_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) Mondoo, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+package provider
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestAccTeamMemberResource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: testAccTeamMemberResourceConfig("test-member-team", "alice@example.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("mondoo_team_member.test", "email", "alice@example.com"),
+					resource.TestCheckResourceAttrSet("mondoo_team_member.test", "team_mrn"),
+					resource.TestCheckResourceAttrSet("mondoo_team_member.test", "member_mrn"),
+				),
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccTeamMemberResourceConfig(teamName, email string) string {
+	return fmt.Sprintf(`
+resource "mondoo_team" "test" {
+  name      = %[1]q
+  scope_mrn = %[3]q
+}
+
+resource "mondoo_team_member" "test" {
+  team_mrn = mondoo_team.test.mrn
+  email    = %[2]q
+}
+`, teamName, email, accSpace.MRN())
+}

--- a/internal/provider/team_member_resource_test.go
+++ b/internal/provider/team_member_resource_test.go
@@ -26,9 +26,10 @@ func TestAccTeamMemberResource(t *testing.T) {
 			},
 			// ImportState testing
 			{
-				ResourceName:      "mondoo_team_member.test",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:                         "mondoo_team_member.test",
+				ImportState:                          true,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "team_mrn",
 				ImportStateIdFunc: func(s *terraform.State) (string, error) {
 					rs, ok := s.RootModule().Resources["mondoo_team_member.test"]
 					if !ok {


### PR DESCRIPTION
## Summary
- Adds `mondoo_team_member` Terraform resource for managing team membership by email
- Implements Create (addTeamMember), Read (teamMember query for drift detection), and Delete (removeTeamMember)
- Both `team_mrn` and `email` are immutable (RequiresReplace) — no Update needed


## Test plan
- [ ] Verify `go build ./...` and `go vet ./...` pass
- [ ] Run acceptance tests: `TF_ACC=1 go test ./internal/provider/ -run TestAccTeamMember -v`
- [ ] Verify adding a member by email creates the membership
- [ ] Verify removing the member via `terraform destroy` cleans up
- [ ] Verify drift detection: manually remove a member and confirm `terraform plan` detects the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)