### PR TITLE
Add wif_subject to export and integration resources

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -1,1 +1,2 @@
 bigquery
+wif

--- a/docs/resources/export_bigquery.md
+++ b/docs/resources/export_bigquery.md
@@ -46,3 +46,4 @@ Export data to Google BigQuery.
 ### Read-Only
 
 - `mrn` (String) Mondoo resource name (MRN) of the integration.
+- `wif_subject` (String) Computed OIDC subject used when Mondoo requests a WIF token for this integration. Configure your cloud provider's trust policy to accept this subject.

--- a/docs/resources/export_gcs_bucket.md
+++ b/docs/resources/export_gcs_bucket.md
@@ -53,6 +53,7 @@ Export data to a Google Cloud Storage bucket.
 ### Read-Only
 
 - `mrn` (String) Mondoo resource name (MRN) of the integration.
+- `wif_subject` (String) Computed OIDC subject used when Mondoo requests a WIF token for this integration. Configure your cloud provider's trust policy to accept this subject.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`

--- a/docs/resources/integration_aws.md
+++ b/docs/resources/integration_aws.md
@@ -57,6 +57,7 @@ resource "mondoo_integration_aws" "name" {
 ### Read-Only
 
 - `mrn` (String) Integration identifier
+- `wif_subject` (String) Computed OIDC subject used when Mondoo requests a WIF token for this integration. Configure your cloud provider's trust policy to accept this subject.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`

--- a/docs/resources/integration_gcp.md
+++ b/docs/resources/integration_gcp.md
@@ -84,6 +84,7 @@ resource "mondoo_integration_gcp" "name" {
 ### Read-Only
 
 - `mrn` (String) Integration identifier
+- `wif_subject` (String) Computed OIDC subject used when Mondoo requests a WIF token for this integration. Configure your cloud provider's trust policy to accept this subject.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`

--- a/internal/provider/export_bigquery.go
+++ b/internal/provider/export_bigquery.go
@@ -36,9 +36,10 @@ type BigQueryExportResourceModel struct {
 	ScopeMrn types.String `tfsdk:"scope_mrn"`
 
 	// integration details
-	Mrn       types.String `tfsdk:"mrn"`
-	Name      types.String `tfsdk:"name"`
-	DatasetID types.String `tfsdk:"dataset_id"`
+	Mrn        types.String `tfsdk:"mrn"`
+	Name       types.String `tfsdk:"name"`
+	DatasetID  types.String `tfsdk:"dataset_id"`
+	WifSubject types.String `tfsdk:"wif_subject"`
 
 	// credentials
 	ServiceAccountKey types.String `tfsdk:"service_account_key"`
@@ -113,6 +114,13 @@ func (r *ExportBigQueryResource) Schema(ctx context.Context, req resource.Schema
 				Sensitive:           true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"wif_subject": schema.StringAttribute{
+				MarkdownDescription: "Computed OIDC subject used when Mondoo requests a WIF token for this integration. Configure your cloud provider's trust policy to accept this subject.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 		},
@@ -209,6 +217,16 @@ func (r *ExportBigQueryResource) Create(ctx context.Context, req resource.Create
 	data.Mrn = types.StringValue(string(integration.Mrn))
 	data.Name = types.StringValue(string(integration.Name))
 
+	// Fetch the full integration to populate server-computed fields (e.g. wif_subject)
+	fetched, err := r.client.GetClientIntegration(ctx, string(integration.Mrn))
+	if err != nil {
+		resp.Diagnostics.AddWarning("Client Warning",
+			fmt.Sprintf("Unable to fetch integration after create to populate computed fields. Got error: %s", err))
+		data.WifSubject = types.StringNull()
+	} else {
+		data.WifSubject = types.StringValue(fetched.ConfigurationOptions.BigqueryConfigurationOptions.WifSubject)
+	}
+
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -231,6 +249,7 @@ func (r *ExportBigQueryResource) Read(ctx context.Context, req resource.ReadRequ
 
 	// Update the state with the latest information
 	data.Name = types.StringValue(integration.Name)
+	data.WifSubject = types.StringValue(integration.ConfigurationOptions.BigqueryConfigurationOptions.WifSubject)
 	// Note: We don't update service_account_key to avoid showing sensitive data
 
 	// Save updated data into Terraform state
@@ -294,6 +313,7 @@ func (r *ExportBigQueryResource) ImportState(ctx context.Context, req resource.I
 		Name:              types.StringValue(integration.Name),
 		ScopeMrn:          types.StringValue(integration.ScopeMRN()),
 		DatasetID:         types.StringValue(integration.ConfigurationOptions.BigqueryConfigurationOptions.DatasetId),
+		WifSubject:        types.StringValue(integration.ConfigurationOptions.BigqueryConfigurationOptions.WifSubject),
 		ServiceAccountKey: types.StringPointerValue(nil), // Don't expose sensitive data
 	}
 

--- a/internal/provider/export_gcs_bucket.go
+++ b/internal/provider/export_gcs_bucket.go
@@ -42,6 +42,7 @@ type ExportGcsBucketResourceModel struct {
 	Name         types.String `tfsdk:"name"`
 	BucketName   types.String `tfsdk:"bucket_name"`
 	ExportFormat types.String `tfsdk:"export_format"`
+	WifSubject   types.String `tfsdk:"wif_subject"`
 
 	// credentials
 	Credential gcsBucketExportCredentialModel `tfsdk:"credentials"`
@@ -121,6 +122,13 @@ func (r *ExportGcsBucketResource) Schema(ctx context.Context, req resource.Schem
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"wif_subject": schema.StringAttribute{
+				MarkdownDescription: "Computed OIDC subject used when Mondoo requests a WIF token for this integration. Configure your cloud provider's trust policy to accept this subject.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"credentials": schema.SingleNestedAttribute{
@@ -235,6 +243,16 @@ func (r *ExportGcsBucketResource) Create(ctx context.Context, req resource.Creat
 	data.Mrn = types.StringValue(string(integration.Mrn))
 	data.Name = types.StringValue(string(integration.Name))
 
+	// Fetch the full integration to populate server-computed fields (e.g. wif_subject)
+	fetched, err := r.client.GetClientIntegration(ctx, string(integration.Mrn))
+	if err != nil {
+		resp.Diagnostics.AddWarning("Client Warning",
+			fmt.Sprintf("Unable to fetch integration after create to populate computed fields. Got error: %s", err))
+		data.WifSubject = types.StringNull()
+	} else {
+		data.WifSubject = types.StringValue(fetched.ConfigurationOptions.GcsBucketConfigurationOptions.WifSubject)
+	}
+
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -249,7 +267,13 @@ func (r *ExportGcsBucketResource) Read(ctx context.Context, req resource.ReadReq
 		return
 	}
 
-	// Read API call logic
+	// Refresh server-computed fields (e.g. wif_subject) from the API.
+	integration, err := r.client.GetClientIntegration(ctx, data.Mrn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading GCS bucket export integration", err.Error())
+		return
+	}
+	data.WifSubject = types.StringValue(integration.ConfigurationOptions.GcsBucketConfigurationOptions.WifSubject)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -319,6 +343,7 @@ func (r *ExportGcsBucketResource) ImportState(ctx context.Context, req resource.
 		ScopeMrn:     types.StringValue(integration.ScopeMRN()),
 		BucketName:   types.StringValue(integration.ConfigurationOptions.GcsBucketConfigurationOptions.Bucket),
 		ExportFormat: types.StringValue(integration.ConfigurationOptions.GcsBucketConfigurationOptions.Output),
+		WifSubject:   types.StringValue(integration.ConfigurationOptions.GcsBucketConfigurationOptions.WifSubject),
 
 		Credential: gcsBucketExportCredentialModel{
 			PrivateKey: types.StringPointerValue(nil),

--- a/internal/provider/gql.go
+++ b/internal/provider/gql.go
@@ -839,8 +839,9 @@ type GithubConfigurationOptions struct {
 }
 
 type GcsBucketConfigurationOptions struct {
-	Bucket string
-	Output string
+	Bucket     string
+	Output     string
+	WifSubject string
 }
 
 type AwsS3ConfigurationOptions struct {
@@ -850,7 +851,8 @@ type AwsS3ConfigurationOptions struct {
 }
 
 type BigqueryConfigurationOptions struct {
-	DatasetId string
+	DatasetId  string
+	WifSubject string
 }
 
 type GitlabConfigurationOptions struct {
@@ -875,11 +877,13 @@ type MsIntuneConfigurationOptions struct {
 type HostedAwsConfigurationOptions struct {
 	AccessKeyId string
 	Role        string
+	WifSubject  string
 }
 
 type GcpConfigurationOptions struct {
 	ProjectId   string
 	DiscoverAll bool
+	WifSubject  string
 }
 
 type ShodanConfigurationOptions struct {

--- a/internal/provider/integration_aws_resource.go
+++ b/internal/provider/integration_aws_resource.go
@@ -38,8 +38,9 @@ type integrationAwsResourceModel struct {
 	SpaceID types.String `tfsdk:"space_id"`
 
 	// integration details
-	Mrn  types.String `tfsdk:"mrn"`
-	Name types.String `tfsdk:"name"`
+	Mrn        types.String `tfsdk:"mrn"`
+	Name       types.String `tfsdk:"name"`
+	WifSubject types.String `tfsdk:"wif_subject"`
 
 	// AWS credentials
 	Credential integrationAwsCredentialModel `tfsdk:"credentials"`
@@ -114,6 +115,13 @@ func (r *integrationAwsResource) Schema(ctx context.Context, req resource.Schema
 				Required:            true,
 				Validators: []validator.String{
 					stringvalidator.LengthAtMost(250),
+				},
+			},
+			"wif_subject": schema.StringAttribute{
+				MarkdownDescription: "Computed OIDC subject used when Mondoo requests a WIF token for this integration. Configure your cloud provider's trust policy to accept this subject.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"credentials": schema.SingleNestedAttribute{
@@ -229,6 +237,16 @@ func (r *integrationAwsResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringValue(string(integration.Name))
 	data.SpaceID = types.StringValue(space.ID())
 
+	// Fetch the full integration to populate server-computed fields (e.g. wif_subject)
+	fetched, err := r.client.GetClientIntegration(ctx, string(integration.Mrn))
+	if err != nil {
+		resp.Diagnostics.AddWarning("Client Warning",
+			fmt.Sprintf("Unable to fetch integration after create to populate computed fields. Got error: %s", err))
+		data.WifSubject = types.StringNull()
+	} else {
+		data.WifSubject = types.StringValue(fetched.ConfigurationOptions.HostedAwsConfigurationOptions.WifSubject)
+	}
+
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -243,7 +261,13 @@ func (r *integrationAwsResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	// Read API call logic
+	// Refresh server-computed fields (e.g. wif_subject) from the API.
+	integration, err := r.client.GetClientIntegration(ctx, data.Mrn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading AWS integration", err.Error())
+		return
+	}
+	data.WifSubject = types.StringValue(integration.ConfigurationOptions.HostedAwsConfigurationOptions.WifSubject)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -310,9 +334,10 @@ func (r *integrationAwsResource) ImportState(ctx context.Context, req resource.I
 	}
 
 	model := integrationAwsResourceModel{
-		SpaceID: types.StringValue(integration.SpaceID()),
-		Mrn:     types.StringValue(integration.Mrn),
-		Name:    types.StringValue(integration.Name),
+		SpaceID:    types.StringValue(integration.SpaceID()),
+		Mrn:        types.StringValue(integration.Mrn),
+		Name:       types.StringValue(integration.Name),
+		WifSubject: types.StringValue(integration.ConfigurationOptions.HostedAwsConfigurationOptions.WifSubject),
 		Credential: integrationAwsCredentialModel{
 			Role: &roleCredentialModel{
 				RoleArn:    types.StringValue(integration.ConfigurationOptions.HostedAwsConfigurationOptions.Role),

--- a/internal/provider/integration_gcp_resource.go
+++ b/internal/provider/integration_gcp_resource.go
@@ -35,9 +35,10 @@ type integrationGcpResourceModel struct {
 	SpaceID types.String `tfsdk:"space_id"`
 
 	// integration details
-	Mrn       types.String `tfsdk:"mrn"`
-	Name      types.String `tfsdk:"name"`
-	ProjectId types.String `tfsdk:"project_id"`
+	Mrn        types.String `tfsdk:"mrn"`
+	Name       types.String `tfsdk:"name"`
+	ProjectId  types.String `tfsdk:"project_id"`
+	WifSubject types.String `tfsdk:"wif_subject"`
 
 	// credentials
 	Credential integrationGcpCredentialModel `tfsdk:"credentials"`
@@ -80,6 +81,13 @@ func (r *integrationGcpResource) Schema(ctx context.Context, req resource.Schema
 			"project_id": schema.StringAttribute{
 				MarkdownDescription: "GCP project ID",
 				Optional:            true,
+			},
+			"wif_subject": schema.StringAttribute{
+				MarkdownDescription: "Computed OIDC subject used when Mondoo requests a WIF token for this integration. Configure your cloud provider's trust policy to accept this subject.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"credentials": schema.SingleNestedAttribute{
 				Required: true,
@@ -169,6 +177,16 @@ func (r *integrationGcpResource) Create(ctx context.Context, req resource.Create
 	data.Name = types.StringValue(string(integration.Name))
 	data.SpaceID = types.StringValue(space.ID())
 
+	// Fetch the full integration to populate server-computed fields (e.g. wif_subject)
+	fetched, err := r.client.GetClientIntegration(ctx, string(integration.Mrn))
+	if err != nil {
+		resp.Diagnostics.AddWarning("Client Warning",
+			fmt.Sprintf("Unable to fetch integration after create to populate computed fields. Got error: %s", err))
+		data.WifSubject = types.StringNull()
+	} else {
+		data.WifSubject = types.StringValue(fetched.ConfigurationOptions.GcpConfigurationOptions.WifSubject)
+	}
+
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -183,7 +201,13 @@ func (r *integrationGcpResource) Read(ctx context.Context, req resource.ReadRequ
 		return
 	}
 
-	// Read API call logic
+	// Refresh server-computed fields (e.g. wif_subject) from the API.
+	integration, err := r.client.GetClientIntegration(ctx, data.Mrn.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Error reading GCP integration", err.Error())
+		return
+	}
+	data.WifSubject = types.StringValue(integration.ConfigurationOptions.GcpConfigurationOptions.WifSubject)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -255,10 +279,11 @@ func (r *integrationGcpResource) ImportState(ctx context.Context, req resource.I
 	}
 
 	model := integrationGcpResourceModel{
-		Mrn:       types.StringValue(integration.Mrn),
-		Name:      types.StringValue(integration.Name),
-		SpaceID:   types.StringValue(integration.SpaceID()),
-		ProjectId: types.StringValue(integration.ConfigurationOptions.GcpConfigurationOptions.ProjectId),
+		Mrn:        types.StringValue(integration.Mrn),
+		Name:       types.StringValue(integration.Name),
+		SpaceID:    types.StringValue(integration.SpaceID()),
+		ProjectId:  types.StringValue(integration.ConfigurationOptions.GcpConfigurationOptions.ProjectId),
+		WifSubject: types.StringValue(integration.ConfigurationOptions.GcpConfigurationOptions.WifSubject),
 		Credential: integrationGcpCredentialModel{
 			PrivateKey: types.StringPointerValue(nil),
 		},


### PR DESCRIPTION
## Summary

- Expose the server-computed `wif_subject` as a read-only attribute on `mondoo_export_gcs_bucket`, `mondoo_export_bigquery`, `mondoo_integration_gcp`, and `mondoo_integration_aws`.
- Populate it on Create (via a post-create `GetClientIntegration` call, since the create payload returns only `mrn`/`name`/`token`), on Read, and on ImportState.
- Skipped `mondoo_export_s3` — the server schema does not expose `wifSubject` on `AwsS3ConfigurationOptions`.

## Why

When a WIF-backed integration is provisioned, the Mondoo server generates the OIDC subject that its JWT tokens will carry. Customers need that value to configure their cloud provider's trust policy (e.g. a `google_iam_workload_identity_pool_provider` `attribute_condition`). Surfacing it in terraform state lets users wire up the full trust setup without a second out-of-band lookup.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -c -o /dev/null ./internal/provider/...` (tests compile)
- [x] `make generate` regenerates the four docs pages with the new attribute
- [ ] Acceptance test against a dev Mondoo environment: create a WIF-configured export/integration with each of the four resources and verify `wif_subject` shows up in `terraform show` and that a second `terraform plan` is a no-op
- [ ] `terraform import` an existing integration and verify `wif_subject` lands in state

🤖 Generated with [Claude Code](https://claude.com/claude-code)