### PR TITLE
feat(azure): Workload Identity Federation for mondoo_integration_azure

### DIFF
--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -273,26 +273,288 @@ resource "mondoo_integration_azure" "azure_integration" {
 }
 ```
 
+```terraform
+# Workload Identity Federation (keyless) example
+# -----------------------------------------------
+#
+# This example wires up a Mondoo Azure integration using Workload Identity
+# Federation (WIF). No certificate or client secret is stored — Mondoo
+# authenticates as a federated workload.
+#
+# DAG: azuread_application → mondoo_integration_azure(use_wif=true) →
+#      azuread_application_federated_identity_credential
+#
+# Usage:
+#   terraform init
+#   terraform apply -var tenant_id=<your-tenant-id> \
+#                   -var primary_subscription=<your-subscription-id>
+
+# Variables
+# ----------------------------------------------
+
+variable "tenant_id" {
+  description = "The Azure Active Directory Tenant ID"
+  type        = string
+  default     = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+}
+
+variable "primary_subscription" {
+  description = "The primary Azure Subscription ID"
+  type        = string
+  default     = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+}
+
+locals {
+  mondoo_security_integration_name = "Mondoo Security Integration (WIF)"
+}
+
+# Azure AD Application
+# ----------------------------------------------
+
+provider "azuread" {
+  tenant_id = var.tenant_id
+}
+
+data "azuread_client_config" "current" {}
+
+# Create the Azure AD application for Mondoo
+resource "azuread_application" "mondoo_security" {
+  display_name = local.mondoo_security_integration_name
+
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+
+    resource_access {
+      id   = "246dd0d5-5bd0-4def-940b-0421030a5b68"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "e321f0bb-e7f7-481e-bb28-e3b0b32d4bd0"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "5e0edab9-c148-49d0-b423-ac253e121825"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "bf394140-e372-4bf9-a898-299cfc7564e5"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "6e472fd1-ad78-48da-a0f0-97ab2c6b769e"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "dc5007c0-2d7d-4c42-879c-2dab87571379"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "b0afded3-3588-46d8-8b3d-9842eff778da"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "7ab1d382-f21e-4acd-a863-ba3e13f7da61"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "197ee4e9-b993-4066-898f-d6aecc55125b"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "f8f035bb-2cce-47fb-8bf5-7baf3ecbee48"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "dbb9058a-0e50-45d7-ae91-66909b5d4664"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "9e640839-a198-48fb-8b9a-013fd6f6cbcd"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "37730810-e9ba-4e46-b07e-8ca78d182097"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "c7fbd983-d9aa-4fa7-84b8-17382c103bc4"
+      type = "Role"
+    }
+  }
+}
+
+# Create a service principal for the application
+resource "azuread_service_principal" "mondoo_security" {
+  client_id                    = azuread_application.mondoo_security.client_id
+  app_role_assignment_required = false
+  owners                       = [data.azuread_client_config.current.object_id]
+}
+
+# Azure Permissions
+# ----------------------------------------------
+
+provider "azurerm" {
+  tenant_id = var.tenant_id
+  features {}
+}
+
+data "azurerm_subscription" "primary" {
+  subscription_id = var.primary_subscription
+}
+
+data "azurerm_subscriptions" "available" {}
+
+# Custom role with the permissions Mondoo needs
+resource "azurerm_role_definition" "mondoo_security_role" {
+  name        = "tf-mondoo-security-role-wif"
+  description = "Permissions for Mondoo Security (WIF mode)"
+  scope       = data.azurerm_subscription.primary.id
+
+  permissions {
+    actions = [
+      "Microsoft.Authorization/*/read",
+      "Microsoft.ResourceHealth/availabilityStatuses/read",
+      "Microsoft.Insights/alertRules/*",
+      "Microsoft.Resources/deployments/*",
+      "Microsoft.Resources/subscriptions/resourceGroups/read",
+      "Microsoft.Support/*",
+      "Microsoft.Web/listSitesAssignedToHostName/read",
+      "Microsoft.Web/serverFarms/read",
+      "Microsoft.Web/sites/config/read",
+      "Microsoft.Web/sites/config/web/appsettings/read",
+      "Microsoft.Web/sites/config/web/connectionstrings/read",
+      "Microsoft.Web/sites/config/appsettings/read",
+      "Microsoft.web/sites/config/snapshots/read",
+      "Microsoft.Web/sites/config/list/action",
+      "Microsoft.Web/sites/read",
+      "Microsoft.KeyVault/checkNameAvailability/read",
+      "Microsoft.KeyVault/deletedVaults/read",
+      "Microsoft.KeyVault/locations/*/read",
+      "Microsoft.KeyVault/vaults/*/read",
+      "Microsoft.KeyVault/operations/read",
+      "Microsoft.Compute/virtualMachines/runCommands/read",
+      "Microsoft.Compute/virtualMachines/runCommands/write",
+      "Microsoft.Compute/virtualMachines/runCommands/delete"
+    ]
+    not_actions = []
+    data_actions = [
+      "Microsoft.KeyVault/vaults/*/read",
+      "Microsoft.KeyVault/vaults/secrets/readMetadata/action"
+    ]
+    not_data_actions = []
+  }
+
+  assignable_scopes = data.azurerm_subscriptions.available.subscriptions[*].id
+}
+
+resource "azurerm_role_assignment" "mondoo_security" {
+  count              = length(data.azurerm_subscriptions.available.subscriptions)
+  scope              = data.azurerm_subscriptions.available.subscriptions[count.index].id
+  role_definition_id = azurerm_role_definition.mondoo_security_role.role_definition_resource_id
+  principal_id       = azuread_service_principal.mondoo_security.object_id
+}
+
+resource "azurerm_role_assignment" "reader" {
+  count                = length(data.azurerm_subscriptions.available.subscriptions)
+  scope                = data.azurerm_subscriptions.available.subscriptions[count.index].id
+  role_definition_name = "Reader"
+  principal_id         = azuread_service_principal.mondoo_security.object_id
+}
+
+# Mondoo Integration (keyless / WIF)
+# ----------------------------------------------
+
+provider "mondoo" {
+  space = "hungry-poet-123456"
+}
+
+# Step 1: Create the Mondoo integration with use_wif=true.
+# Mondoo returns wif_subject and wif_issuer_url, which are used in step 2.
+resource "mondoo_integration_azure" "this" {
+  name      = "Azure ${local.mondoo_security_integration_name}"
+  tenant_id = var.tenant_id
+  client_id = azuread_application.mondoo_security.client_id
+  scan_vms  = true
+  use_wif   = true
+
+  depends_on = [
+    azuread_application.mondoo_security,
+    azuread_service_principal.mondoo_security,
+    azurerm_role_assignment.mondoo_security,
+    azurerm_role_assignment.reader,
+  ]
+}
+
+# Step 2: Wire up the federated identity credential using the subject/issuer
+# that Mondoo emits. This allows Mondoo to authenticate without a certificate.
+resource "azuread_application_federated_identity_credential" "mondoo" {
+  application_id = azuread_application.mondoo_security.id
+  display_name   = "mondoo"
+  issuer         = mondoo_integration_azure.this.wif_issuer_url
+  subject        = mondoo_integration_azure.this.wif_subject
+  audiences      = ["api://AzureADTokenExchange"]
+}
+
+# Outputs
+# ----------------------------------------------
+
+output "integration_mrn" {
+  value       = mondoo_integration_azure.this.mrn
+  description = "MRN of the Mondoo Azure integration"
+}
+
+output "wif_subject" {
+  value       = mondoo_integration_azure.this.wif_subject
+  description = "WIF subject configured on the federated identity credential"
+}
+
+output "wif_issuer_url" {
+  value       = mondoo_integration_azure.this.wif_issuer_url
+  description = "WIF issuer URL configured on the federated identity credential"
+}
+```
+
 <!-- schema generated by tfplugindocs -->
 ## Schema
 
 ### Required
 
 - `client_id` (String) Azure client ID.
-- `credentials` (Attributes) (see [below for nested schema](#nestedatt--credentials))
 - `name` (String) Name of the integration.
 - `tenant_id` (String) Azure tenant ID.
 
 ### Optional
 
+- `credentials` (Attributes) Certificate credentials for Azure integration. Mutually exclusive with `use_wif`. (see [below for nested schema](#nestedatt--credentials))
 - `scan_vms` (Boolean) Scan VMs.
 - `space_id` (String) Mondoo space identifier. If there is no space ID, the provider space is used.
 - `subscription_allow_list` (List of String) List of Azure subscriptions to scan.
 - `subscription_deny_list` (List of String) List of Azure subscriptions to exclude from scanning.
+- `use_wif` (Boolean) Use Workload Identity Federation (keyless) instead of a certificate. Mutually exclusive with `credentials`.
 
 ### Read-Only
 
 - `mrn` (String) Integration identifier
+- `wif_issuer_url` (String) The WIF issuer URL (populated by Mondoo after creation). Use as the `issuer` of the `azuread_application_federated_identity_credential` resource.
+- `wif_subject` (String) The WIF subject (populated by Mondoo after creation). Use as the `subject` of the `azuread_application_federated_identity_credential` resource.
 
 <a id="nestedatt--credentials"></a>
 ### Nested Schema for `credentials`

--- a/examples/resources/mondoo_integration_azure/resource_wif.tf
+++ b/examples/resources/mondoo_integration_azure/resource_wif.tf
@@ -1,0 +1,256 @@
+# Workload Identity Federation (keyless) example
+# -----------------------------------------------
+#
+# This example wires up a Mondoo Azure integration using Workload Identity
+# Federation (WIF). No certificate or client secret is stored — Mondoo
+# authenticates as a federated workload.
+#
+# DAG: azuread_application → mondoo_integration_azure(use_wif=true) →
+#      azuread_application_federated_identity_credential
+#
+# Usage:
+#   terraform init
+#   terraform apply -var tenant_id=<your-tenant-id> \
+#                   -var primary_subscription=<your-subscription-id>
+
+# Variables
+# ----------------------------------------------
+
+variable "tenant_id" {
+  description = "The Azure Active Directory Tenant ID"
+  type        = string
+  default     = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+}
+
+variable "primary_subscription" {
+  description = "The primary Azure Subscription ID"
+  type        = string
+  default     = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+}
+
+locals {
+  mondoo_security_integration_name = "Mondoo Security Integration (WIF)"
+}
+
+# Azure AD Application
+# ----------------------------------------------
+
+provider "azuread" {
+  tenant_id = var.tenant_id
+}
+
+data "azuread_client_config" "current" {}
+
+# Create the Azure AD application for Mondoo
+resource "azuread_application" "mondoo_security" {
+  display_name = local.mondoo_security_integration_name
+
+  required_resource_access {
+    resource_app_id = "00000003-0000-0000-c000-000000000000" # Microsoft Graph
+
+    resource_access {
+      id   = "246dd0d5-5bd0-4def-940b-0421030a5b68"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "e321f0bb-e7f7-481e-bb28-e3b0b32d4bd0"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "5e0edab9-c148-49d0-b423-ac253e121825"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "bf394140-e372-4bf9-a898-299cfc7564e5"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "6e472fd1-ad78-48da-a0f0-97ab2c6b769e"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "dc5007c0-2d7d-4c42-879c-2dab87571379"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "b0afded3-3588-46d8-8b3d-9842eff778da"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "7ab1d382-f21e-4acd-a863-ba3e13f7da61"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "197ee4e9-b993-4066-898f-d6aecc55125b"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "9a5d68dd-52b0-4cc2-bd40-abcf44ac3a30"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "f8f035bb-2cce-47fb-8bf5-7baf3ecbee48"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "dbb9058a-0e50-45d7-ae91-66909b5d4664"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "9e640839-a198-48fb-8b9a-013fd6f6cbcd"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "37730810-e9ba-4e46-b07e-8ca78d182097"
+      type = "Role"
+    }
+
+    resource_access {
+      id   = "c7fbd983-d9aa-4fa7-84b8-17382c103bc4"
+      type = "Role"
+    }
+  }
+}
+
+# Create a service principal for the application
+resource "azuread_service_principal" "mondoo_security" {
+  client_id                    = azuread_application.mondoo_security.client_id
+  app_role_assignment_required = false
+  owners                       = [data.azuread_client_config.current.object_id]
+}
+
+# Azure Permissions
+# ----------------------------------------------
+
+provider "azurerm" {
+  tenant_id = var.tenant_id
+  features {}
+}
+
+data "azurerm_subscription" "primary" {
+  subscription_id = var.primary_subscription
+}
+
+data "azurerm_subscriptions" "available" {}
+
+# Custom role with the permissions Mondoo needs
+resource "azurerm_role_definition" "mondoo_security_role" {
+  name        = "tf-mondoo-security-role-wif"
+  description = "Permissions for Mondoo Security (WIF mode)"
+  scope       = data.azurerm_subscription.primary.id
+
+  permissions {
+    actions = [
+      "Microsoft.Authorization/*/read",
+      "Microsoft.ResourceHealth/availabilityStatuses/read",
+      "Microsoft.Insights/alertRules/*",
+      "Microsoft.Resources/deployments/*",
+      "Microsoft.Resources/subscriptions/resourceGroups/read",
+      "Microsoft.Support/*",
+      "Microsoft.Web/listSitesAssignedToHostName/read",
+      "Microsoft.Web/serverFarms/read",
+      "Microsoft.Web/sites/config/read",
+      "Microsoft.Web/sites/config/web/appsettings/read",
+      "Microsoft.Web/sites/config/web/connectionstrings/read",
+      "Microsoft.Web/sites/config/appsettings/read",
+      "Microsoft.web/sites/config/snapshots/read",
+      "Microsoft.Web/sites/config/list/action",
+      "Microsoft.Web/sites/read",
+      "Microsoft.KeyVault/checkNameAvailability/read",
+      "Microsoft.KeyVault/deletedVaults/read",
+      "Microsoft.KeyVault/locations/*/read",
+      "Microsoft.KeyVault/vaults/*/read",
+      "Microsoft.KeyVault/operations/read",
+      "Microsoft.Compute/virtualMachines/runCommands/read",
+      "Microsoft.Compute/virtualMachines/runCommands/write",
+      "Microsoft.Compute/virtualMachines/runCommands/delete"
+    ]
+    not_actions = []
+    data_actions = [
+      "Microsoft.KeyVault/vaults/*/read",
+      "Microsoft.KeyVault/vaults/secrets/readMetadata/action"
+    ]
+    not_data_actions = []
+  }
+
+  assignable_scopes = data.azurerm_subscriptions.available.subscriptions[*].id
+}
+
+resource "azurerm_role_assignment" "mondoo_security" {
+  count              = length(data.azurerm_subscriptions.available.subscriptions)
+  scope              = data.azurerm_subscriptions.available.subscriptions[count.index].id
+  role_definition_id = azurerm_role_definition.mondoo_security_role.role_definition_resource_id
+  principal_id       = azuread_service_principal.mondoo_security.object_id
+}
+
+resource "azurerm_role_assignment" "reader" {
+  count                = length(data.azurerm_subscriptions.available.subscriptions)
+  scope                = data.azurerm_subscriptions.available.subscriptions[count.index].id
+  role_definition_name = "Reader"
+  principal_id         = azuread_service_principal.mondoo_security.object_id
+}
+
+# Mondoo Integration (keyless / WIF)
+# ----------------------------------------------
+
+provider "mondoo" {
+  space = "hungry-poet-123456"
+}
+
+# Step 1: Create the Mondoo integration with use_wif=true.
+# Mondoo returns wif_subject and wif_issuer_url, which are used in step 2.
+resource "mondoo_integration_azure" "this" {
+  name      = "Azure ${local.mondoo_security_integration_name}"
+  tenant_id = var.tenant_id
+  client_id = azuread_application.mondoo_security.client_id
+  scan_vms  = true
+  use_wif   = true
+
+  depends_on = [
+    azuread_application.mondoo_security,
+    azuread_service_principal.mondoo_security,
+    azurerm_role_assignment.mondoo_security,
+    azurerm_role_assignment.reader,
+  ]
+}
+
+# Step 2: Wire up the federated identity credential using the subject/issuer
+# that Mondoo emits. This allows Mondoo to authenticate without a certificate.
+resource "azuread_application_federated_identity_credential" "mondoo" {
+  application_id = azuread_application.mondoo_security.id
+  display_name   = "mondoo"
+  issuer         = mondoo_integration_azure.this.wif_issuer_url
+  subject        = mondoo_integration_azure.this.wif_subject
+  audiences      = ["api://AzureADTokenExchange"]
+}
+
+# Outputs
+# ----------------------------------------------
+
+output "integration_mrn" {
+  value       = mondoo_integration_azure.this.mrn
+  description = "MRN of the Mondoo Azure integration"
+}
+
+output "wif_subject" {
+  value       = mondoo_integration_azure.this.wif_subject
+  description = "WIF subject configured on the federated identity credential"
+}
+
+output "wif_issuer_url" {
+  value       = mondoo_integration_azure.this.wif_issuer_url
+  description = "WIF issuer URL configured on the federated identity credential"
+}

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -176,7 +176,7 @@ func findField(obj any, fieldName string) (reflect.StructField, bool) {
 	val := reflect.TypeOf(obj)
 
 	// If the object is a pointer, get the underlying element
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.15.0
 	github.com/stretchr/testify v1.11.1
-	go.mondoo.com/mondoo-go v0.0.0-20260427163116-d568d47e9fb9
+	go.mondoo.com/mondoo-go v0.0.0-20260629182148-c720f402b5de
 	go.mondoo.com/mql/v13 v13.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )
@@ -170,5 +170,3 @@ require (
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
-
-replace go.mondoo.com/mondoo-go => /Users/vj/go/src/go.mondoo.io/mondoo-go

--- a/go.mod
+++ b/go.mod
@@ -170,3 +170,5 @@ require (
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )
+
+replace go.mondoo.com/mondoo-go => /Users/vj/go/src/go.mondoo.io/mondoo-go

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ go.abhg.dev/goldmark/frontmatter v0.2.0/go.mod h1:XqrEkZuM57djk7zrlRUB02x8I5J0px
 go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=
 go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
-go.mondoo.com/mondoo-go v0.0.0-20260427163116-d568d47e9fb9 h1:BWLKRLcqSYy395qwSypGZLk0bx/htOVs9cG0hXjY+po=
-go.mondoo.com/mondoo-go v0.0.0-20260427163116-d568d47e9fb9/go.mod h1:71ONiTX5I/jMdghOaeovcexBvxPvD1WcZqAEzz4RGOs=
+go.mondoo.com/mondoo-go v0.0.0-20260629182148-c720f402b5de h1:YcqBz2oshq5ZwoGwBwP1d7wOSgD9D/L+wGrpaMpO3cY=
+go.mondoo.com/mondoo-go v0.0.0-20260629182148-c720f402b5de/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
 go.mondoo.com/mql/v13 v13.5.1 h1:WpXdy7h6y28npvUYg2YaLa++8CbVjCGQoDiL+IwXbc8=
 go.mondoo.com/mql/v13 v13.5.1/go.mod h1:fZ2CbY2dmjBBiLIKJDuW9HqEGFfzsR/n0kxIRRw6zik=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=

--- a/internal/provider/gql.go
+++ b/internal/provider/gql.go
@@ -816,7 +816,9 @@ type AzureConfigurationOptions struct {
 	SubscriptionsWhitelist []string
 	SubscriptionsBlacklist []string
 	ScanVms                bool
-	// INTERIM: hand-added; re-confirm via make generate once the server schema is deployed.
+	// Computed Workload Identity Federation fields returned by the server. The
+	// SDK generates inputs/enums/scalars only (no output types), so these are
+	// declared here on the provider's own read-back struct.
 	WifSubject   string
 	WifIssuerUrl string
 }

--- a/internal/provider/gql.go
+++ b/internal/provider/gql.go
@@ -816,6 +816,9 @@ type AzureConfigurationOptions struct {
 	SubscriptionsWhitelist []string
 	SubscriptionsBlacklist []string
 	ScanVms                bool
+	// INTERIM: hand-added; re-confirm via make generate once the server schema is deployed.
+	WifSubject   string
+	WifIssuerUrl string
 }
 
 type HostConfigurationOptions struct {

--- a/internal/provider/integration_azure_resource.go
+++ b/internal/provider/integration_azure_resource.go
@@ -277,7 +277,18 @@ func (r *integrationAzureResource) Create(ctx context.Context, req resource.Crea
 	// These are returned by the server after creation and used to wire up the
 	// azuread_application_federated_identity_credential resource.
 	fetchedIntegration, err := r.client.GetClientIntegration(ctx, data.Mrn.ValueString())
-	if err == nil {
+	if err != nil {
+		// In WIF mode, empty wif_subject/wif_issuer_url would silently misconfigure
+		// the downstream azuread_application_federated_identity_credential, so surface it.
+		if data.UseWif.ValueBool() {
+			resp.Diagnostics.AddWarning(
+				"Unable to read WIF fields",
+				fmt.Sprintf("The integration was created, but its Workload Identity Federation fields "+
+					"(wif_subject, wif_issuer_url) could not be read back: %s. The federated identity "+
+					"credential may receive empty values; re-run 'terraform apply' to refresh.", err),
+			)
+		}
+	} else {
 		data.WifSubject = types.StringValue(fetchedIntegration.ConfigurationOptions.AzureConfigurationOptions.WifSubject)
 		data.WifIssuerUrl = types.StringValue(fetchedIntegration.ConfigurationOptions.AzureConfigurationOptions.WifIssuerUrl)
 	}
@@ -417,18 +428,31 @@ func (r *integrationAzureResource) ImportState(ctx context.Context, req resource
 	allowList := ConvertListValue(integration.ConfigurationOptions.AzureConfigurationOptions.SubscriptionsWhitelist)
 	denyList := ConvertListValue(integration.ConfigurationOptions.AzureConfigurationOptions.SubscriptionsBlacklist)
 
+	azureOpts := integration.ConfigurationOptions.AzureConfigurationOptions
 	model := integrationAzureResourceModel{
 		SpaceID:               types.StringValue(integration.SpaceID()),
 		Mrn:                   types.StringValue(integration.Mrn),
 		Name:                  types.StringValue(integration.Name),
-		ClientId:              types.StringValue(integration.ConfigurationOptions.AzureConfigurationOptions.ClientId),
-		TenantId:              types.StringValue(integration.ConfigurationOptions.AzureConfigurationOptions.TenantId),
+		ClientId:              types.StringValue(azureOpts.ClientId),
+		TenantId:              types.StringValue(azureOpts.TenantId),
 		SubscriptionAllowList: allowList,
 		SubscriptionDenyList:  denyList,
-		Credential:            nil,
-		ScanVms:               types.BoolValue(integration.ConfigurationOptions.AzureConfigurationOptions.ScanVms),
-		WifSubject:            types.StringValue(integration.ConfigurationOptions.AzureConfigurationOptions.WifSubject),
-		WifIssuerUrl:          types.StringValue(integration.ConfigurationOptions.AzureConfigurationOptions.WifIssuerUrl),
+		ScanVms:               types.BoolValue(azureOpts.ScanVms),
+		WifSubject:            types.StringValue(azureOpts.WifSubject),
+		WifIssuerUrl:          types.StringValue(azureOpts.WifIssuerUrl),
+	}
+
+	// Detect the auth mode from the API response so the imported state satisfies
+	// the ExactlyOneOf(use_wif, credentials) validator and matches the user's config.
+	if azureOpts.WifSubject != "" {
+		model.UseWif = types.BoolValue(true)
+		model.Credential = nil
+	} else {
+		// Certificate mode: the PEM is write-only and cannot be read back, so it
+		// is left null — re-supply it in config after import. Setting the
+		// credentials block keeps the import aligned with a certificate config.
+		model.UseWif = types.BoolNull()
+		model.Credential = &integrationAzureCredentialModel{PEMFile: types.StringNull()}
 	}
 
 	resp.State.Set(ctx, &model)

--- a/internal/provider/integration_azure_resource.go
+++ b/internal/provider/integration_azure_resource.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/resourcevalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -23,6 +24,7 @@ import (
 // Ensure provider defined types fully satisfy framework interfaces.
 var _ resource.Resource = (*integrationAzureResource)(nil)
 var _ resource.ResourceWithImportState = (*integrationAzureResource)(nil)
+var _ resource.ResourceWithConfigValidators = (*integrationAzureResource)(nil)
 
 func NewIntegrationAzureResource() resource.Resource {
 	return &integrationAzureResource{}
@@ -45,8 +47,13 @@ type integrationAzureResourceModel struct {
 	SubscriptionDenyList  types.List   `tfsdk:"subscription_deny_list"`
 	ScanVms               types.Bool   `tfsdk:"scan_vms"`
 
-	// credentials
-	Credential integrationAzureCredentialModel `tfsdk:"credentials"`
+	// WIF (Workload Identity Federation) — keyless mode
+	UseWif       types.Bool   `tfsdk:"use_wif"`
+	WifSubject   types.String `tfsdk:"wif_subject"`
+	WifIssuerUrl types.String `tfsdk:"wif_issuer_url"`
+
+	// credentials — certificate mode (nil when use_wif=true)
+	Credential *integrationAzureCredentialModel `tfsdk:"credentials"`
 }
 
 type integrationAzureCredentialModel struct {
@@ -55,6 +62,17 @@ type integrationAzureCredentialModel struct {
 
 func (r *integrationAzureResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_integration_azure"
+}
+
+// ConfigValidators enforces the mutual exclusion between use_wif and credentials.
+// Exactly one of the two must be configured.
+func (r *integrationAzureResource) ConfigValidators(_ context.Context) []resource.ConfigValidator {
+	return []resource.ConfigValidator{
+		resourcevalidator.ExactlyOneOf(
+			path.MatchRoot("use_wif"),
+			path.MatchRoot("credentials"),
+		),
+	}
 }
 
 func (r *integrationAzureResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -117,8 +135,27 @@ func (r *integrationAzureResource) Schema(ctx context.Context, req resource.Sche
 					}...),
 				},
 			},
+			"use_wif": schema.BoolAttribute{
+				MarkdownDescription: "Use Workload Identity Federation (keyless) instead of a certificate. Mutually exclusive with `credentials`.",
+				Optional:            true,
+			},
+			"wif_subject": schema.StringAttribute{
+				MarkdownDescription: "The WIF subject (populated by Mondoo after creation). Use as the `subject` of the `azuread_application_federated_identity_credential` resource.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"wif_issuer_url": schema.StringAttribute{
+				MarkdownDescription: "The WIF issuer URL (populated by Mondoo after creation). Use as the `issuer` of the `azuread_application_federated_identity_credential` resource.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 			"credentials": schema.SingleNestedAttribute{
-				Required: true,
+				MarkdownDescription: "Certificate credentials for Azure integration. Mutually exclusive with `use_wif`.",
+				Optional:            true,
 				Attributes: map[string]schema.Attribute{
 					"pem_file": schema.StringAttribute{
 						MarkdownDescription: "PEM file for Azure integration.",
@@ -187,20 +224,27 @@ func (r *integrationAzureResource) Create(ctx context.Context, req resource.Crea
 		return
 	}
 
+	// Build Azure configuration options — WIF mode or certificate mode.
+	azureOpts := &mondoov1.AzureConfigurationOptionsInput{
+		TenantId:               mondoov1.String(data.TenantId.ValueString()),
+		ClientId:               mondoov1.String(data.ClientId.ValueString()),
+		SubscriptionsWhitelist: &listAllow,
+		SubscriptionsBlacklist: &listDeny,
+		ScanVms:                mondoov1.NewBooleanPtr(mondoov1.Boolean(data.ScanVms.ValueBool())),
+	}
+	if data.UseWif.ValueBool() {
+		azureOpts.UseWif = mondoov1.NewBooleanPtr(mondoov1.Boolean(true))
+	} else {
+		azureOpts.Certificate = mondoov1.NewStringPtr(mondoov1.String(data.Credential.PEMFile.ValueString()))
+	}
+
 	tflog.Debug(ctx, "Creating integration")
 	integration, err := r.client.CreateIntegration(ctx,
 		space.MRN(),
 		data.Name.ValueString(),
 		mondoov1.ClientIntegrationTypeAzure,
 		mondoov1.ClientIntegrationConfigurationInput{
-			AzureConfigurationOptions: &mondoov1.AzureConfigurationOptionsInput{
-				TenantId:               mondoov1.String(data.TenantId.ValueString()),
-				ClientId:               mondoov1.String(data.ClientId.ValueString()),
-				SubscriptionsWhitelist: &listAllow,
-				SubscriptionsBlacklist: &listDeny,
-				ScanVms:                mondoov1.NewBooleanPtr(mondoov1.Boolean(data.ScanVms.ValueBool())),
-				Certificate:            mondoov1.NewStringPtr(mondoov1.String(data.Credential.PEMFile.ValueString())),
-			},
+			AzureConfigurationOptions: azureOpts,
 		})
 	if err != nil {
 		resp.Diagnostics.
@@ -226,6 +270,15 @@ func (r *integrationAzureResource) Create(ctx context.Context, req resource.Crea
 	data.Name = types.StringValue(string(integration.Name))
 	data.SpaceID = types.StringValue(space.ID())
 
+	// Populate WIF computed fields from the integration response.
+	// These are returned by the server after creation and used to wire up the
+	// azuread_application_federated_identity_credential resource.
+	fetchedIntegration, err := r.client.GetClientIntegration(ctx, data.Mrn.ValueString())
+	if err == nil {
+		data.WifSubject = types.StringValue(fetchedIntegration.ConfigurationOptions.AzureConfigurationOptions.WifSubject)
+		data.WifIssuerUrl = types.StringValue(fetchedIntegration.ConfigurationOptions.AzureConfigurationOptions.WifIssuerUrl)
+	}
+
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
@@ -240,7 +293,16 @@ func (r *integrationAzureResource) Read(ctx context.Context, req resource.ReadRe
 		return
 	}
 
-	// Read API call logic
+	// Fetch current state from the API to pick up computed WIF fields.
+	if data.Mrn.ValueString() != "" {
+		integration, err := r.client.GetClientIntegration(ctx, data.Mrn.ValueString())
+		if err != nil {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		data.WifSubject = types.StringValue(integration.ConfigurationOptions.AzureConfigurationOptions.WifSubject)
+		data.WifIssuerUrl = types.StringValue(integration.ConfigurationOptions.AzureConfigurationOptions.WifIssuerUrl)
+	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -274,15 +336,22 @@ func (r *integrationAzureResource) Update(ctx context.Context, req resource.Upda
 		return
 	}
 
+	// Build Azure configuration options — WIF mode or certificate mode.
+	azureOpts := &mondoov1.AzureConfigurationOptionsInput{
+		TenantId:               mondoov1.String(data.TenantId.ValueString()),
+		ClientId:               mondoov1.String(data.ClientId.ValueString()),
+		SubscriptionsWhitelist: &listAllow,
+		SubscriptionsBlacklist: &listDeny,
+		ScanVms:                mondoov1.NewBooleanPtr(mondoov1.Boolean(data.ScanVms.ValueBool())),
+	}
+	if data.UseWif.ValueBool() {
+		azureOpts.UseWif = mondoov1.NewBooleanPtr(mondoov1.Boolean(true))
+	} else {
+		azureOpts.Certificate = mondoov1.NewStringPtr(mondoov1.String(data.Credential.PEMFile.ValueString()))
+	}
+
 	opts := mondoov1.ClientIntegrationConfigurationInput{
-		AzureConfigurationOptions: &mondoov1.AzureConfigurationOptionsInput{
-			TenantId:               mondoov1.String(data.TenantId.ValueString()),
-			ClientId:               mondoov1.String(data.ClientId.ValueString()),
-			SubscriptionsWhitelist: &listAllow,
-			SubscriptionsBlacklist: &listDeny,
-			ScanVms:                mondoov1.NewBooleanPtr(mondoov1.Boolean(data.ScanVms.ValueBool())),
-			Certificate:            mondoov1.NewStringPtr(mondoov1.String(data.Credential.PEMFile.ValueString())),
-		},
+		AzureConfigurationOptions: azureOpts,
 	}
 
 	_, err := r.client.UpdateIntegration(ctx,
@@ -341,10 +410,10 @@ func (r *integrationAzureResource) ImportState(ctx context.Context, req resource
 		TenantId:              types.StringValue(integration.ConfigurationOptions.AzureConfigurationOptions.TenantId),
 		SubscriptionAllowList: allowList,
 		SubscriptionDenyList:  denyList,
-		Credential: integrationAzureCredentialModel{
-			PEMFile: types.StringPointerValue(nil),
-		},
-		ScanVms: types.BoolValue(integration.ConfigurationOptions.AzureConfigurationOptions.ScanVms),
+		Credential:            nil,
+		ScanVms:               types.BoolValue(integration.ConfigurationOptions.AzureConfigurationOptions.ScanVms),
+		WifSubject:            types.StringValue(integration.ConfigurationOptions.AzureConfigurationOptions.WifSubject),
+		WifIssuerUrl:          types.StringValue(integration.ConfigurationOptions.AzureConfigurationOptions.WifIssuerUrl),
 	}
 
 	resp.State.Set(ctx, &model)

--- a/internal/provider/integration_azure_resource.go
+++ b/internal/provider/integration_azure_resource.go
@@ -234,8 +234,11 @@ func (r *integrationAzureResource) Create(ctx context.Context, req resource.Crea
 	}
 	if data.UseWif.ValueBool() {
 		azureOpts.UseWif = mondoov1.NewBooleanPtr(mondoov1.Boolean(true))
-	} else {
+	} else if data.Credential != nil {
 		azureOpts.Certificate = mondoov1.NewStringPtr(mondoov1.String(data.Credential.PEMFile.ValueString()))
+	} else {
+		resp.Diagnostics.AddError("Missing Azure credentials", "Set use_wif = true or provide a credentials block with pem_file.")
+		return
 	}
 
 	tflog.Debug(ctx, "Creating integration")
@@ -297,7 +300,16 @@ func (r *integrationAzureResource) Read(ctx context.Context, req resource.ReadRe
 	if data.Mrn.ValueString() != "" {
 		integration, err := r.client.GetClientIntegration(ctx, data.Mrn.ValueString())
 		if err != nil {
-			resp.State.RemoveResource(ctx)
+			// Only drop the resource from state when it genuinely no longer
+			// exists. A transient error (network, auth, server) must not cause
+			// Terraform to delete the resource from state.
+			if isNotFoundError(err) {
+				resp.State.RemoveResource(ctx)
+				return
+			}
+			resp.Diagnostics.AddError("Client Error",
+				fmt.Sprintf("Unable to read Azure integration: %s", err),
+			)
 			return
 		}
 		data.WifSubject = types.StringValue(integration.ConfigurationOptions.AzureConfigurationOptions.WifSubject)
@@ -346,8 +358,11 @@ func (r *integrationAzureResource) Update(ctx context.Context, req resource.Upda
 	}
 	if data.UseWif.ValueBool() {
 		azureOpts.UseWif = mondoov1.NewBooleanPtr(mondoov1.Boolean(true))
-	} else {
+	} else if data.Credential != nil {
 		azureOpts.Certificate = mondoov1.NewStringPtr(mondoov1.String(data.Credential.PEMFile.ValueString()))
+	} else {
+		resp.Diagnostics.AddError("Missing Azure credentials", "Set use_wif = true or provide a credentials block with pem_file.")
+		return
 	}
 
 	opts := mondoov1.ClientIntegrationConfigurationInput{

--- a/internal/provider/testdata/test-wif-tf.tf
+++ b/internal/provider/testdata/test-wif-tf.tf
@@ -13,7 +13,7 @@ terraform {
 provider "mondoo" {}
 
 resource "mondoo_space" "new_space" {
-    name        = "TF Provider Test Space"
-    description = "A space created when testing the terraform provider (https://github.com/mondoohq/terraform-provider-mondoo)"
-    org_id      = "relaxed-khayyam-961566"
+  name        = "TF Provider Test Space"
+  description = "A space created when testing the terraform provider (https://github.com/mondoohq/terraform-provider-mondoo)"
+  org_id      = "relaxed-khayyam-961566"
 }


### PR DESCRIPTION
## Summary

Adds Workload Identity Federation (WIF/keyless) support to the `mondoo_integration_azure` resource. Instead of storing a certificate, Mondoo authenticates as a federated workload via Azure AD's Federated Identity Credentials — no secrets stored.

### New attributes

| Attribute | Type | Description |
|-----------|------|-------------|
| `use_wif` | `bool`, optional | Set to `true` to enable keyless (WIF) mode. Mutually exclusive with `credentials`. |
| `wif_subject` | `string`, computed | WIF subject emitted by Mondoo after creation. Wire into `azuread_application_federated_identity_credential.subject`. |
| `wif_issuer_url` | `string`, computed | WIF issuer URL emitted by Mondoo after creation. Wire into `azuread_application_federated_identity_credential.issuer`. |

`credentials` remains **optional** (was required); exactly one of `use_wif` or `credentials` must be set (enforced by a resource-level `ExactlyOneOf` validator).

### Terraform DAG (WIF mode)

```hcl
# 1. Create the Azure AD application
resource "azuread_application" "mondoo_security" { ... }

# 2. Register the Mondoo integration — Mondoo returns wif_subject + wif_issuer_url
resource "mondoo_integration_azure" "this" {
  name      = "Mondoo"
  tenant_id = var.tenant_id
  client_id = azuread_application.mondoo_security.client_id
  use_wif   = true
}

# 3. Wire the federated identity credential using the outputs from step 2
resource "azuread_application_federated_identity_credential" "mondoo" {
  application_id = azuread_application.mondoo_security.id
  display_name   = "mondoo"
  issuer         = mondoo_integration_azure.this.wif_issuer_url
  subject        = mondoo_integration_azure.this.wif_subject
  audiences      = ["api://AzureADTokenExchange"]
}
```

A full example is in `examples/resources/mondoo_integration_azure/resource_wif.tf`. The existing certificate-based example in `resource.tf` is unchanged.

### Correctness fixes

- **No nil-pointer panic on Create/Update.** `credentials` is now an optional, nullable block. The `ExactlyOneOf` validator treats a null attribute as "set", so `use_wif = false` with no `credentials` block passes validation and previously dereferenced a nil credentials pointer. Create and Update now guard explicitly: WIF mode, else a present credentials block, else a clear diagnostic — no panic.
- **Read no longer drops state on transient errors.** Previously any error from the integration read removed the resource from Terraform state, so a network/auth/server blip would silently delete the resource. Read now only removes state on a genuine not-found (`isNotFoundError`); any other error surfaces a diagnostic and keeps state.

## Dependencies

Pins `go.mondoo.com/mondoo-go` to the release that includes `AzureConfigurationOptionsInput.UseWif`. The `wif_subject` / `wif_issuer_url` read-back is defined via the provider's own `AzureConfigurationOptions` struct in `gql.go` (the SDK generates inputs/enums/scalars only, not output/response types).

## Scope

Contains only the Azure WIF change, the `mondoo-go` dependency bump, and the regenerated docs/example — no unrelated content.

## Test plan

- [x] `go build ./...` — passes
- [x] `go test ./internal/provider/ -run Azure` — compiles (acceptance tests gated on credentials)
- [ ] Acceptance tests (`TF_ACC=1`) — require a real Azure tenant + Mondoo org credentials
- [ ] Live keyless scan end-to-end: run the WIF Terraform DAG against a real tenant, verify the federated identity credential is created, integration reaches READY, scan returns assets with no secret stored
- [ ] Regression: certificate-based flow without `use_wif` still completes
