### PR TITLE
✨ Set a descriptive User-Agent on the Mondoo GraphQL client

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -187,6 +187,14 @@ func (p *MondooProvider) Configure(ctx context.Context, req provider.ConfigureRe
 		ctx = tflog.SetField(ctx, "provider_space", space)
 	}
 
+	// Set a descriptive User-Agent so provider traffic is identifiable in server
+	// traces instead of the generic mondoo-go SDK UA (mondoo-graphql-client).
+	userAgent := "mondoo-terraform-provider/" + p.version
+	if space != "" {
+		userAgent += " space/" + space
+	}
+	opts = append(opts, option.WithUserAgent(userAgent))
+
 	tflog.Debug(ctx, "Creating Mondoo client")
 	client, err := mondoov1.NewClient(opts...)
 	if err != nil {


### PR DESCRIPTION
## What

Sets a descriptive `User-Agent` on the provider's mondoo-go GraphQL client:
`mondoo-terraform-provider/<version> space/<space>`.

## Why

Today the provider calls `mondoov1.NewClient()` with no `WithUserAgent`, so every request reports as the generic SDK UA `mondoo-graphql-client/<version>` — indistinguishable from the export-runner and any other mondoo-go client in server-side traces. This makes it impossible to attribute request volume.

Provider-driven reconciliation is a significant source of anonymous GraphQL traffic against private instances; a distinct User-Agent makes that traffic identifiable in Honeycomb/observability (and, combined with operation-name-based sampling on the server side, easy to reason about).

🤖 Generated with [Claude Code](https://claude.com/claude-code)