### PR TITLE
feat: sync mondoo_integration_gcp_serverless with the current API schema

### DIFF
--- a/docs/resources/integration_gcp_serverless.md
+++ b/docs/resources/integration_gcp_serverless.md
@@ -61,11 +61,11 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
 - `host_project_id` (String) The GCP project ID where the serverless scanner is deployed.
 - `name` (String) Name of the integration.
 - `region` (String) The GCP region where the serverless scanner is deployed.
-- `scope` (String) The GCP scope to scan. Accepts either a folder ID or an organization ID.
 
 ### Optional
 
 - `scan_configuration` (Attributes) Scan options that control what the deployed scanner scans. (see [below for nested schema](#nestedatt--scan_configuration))
+- `scope` (String) The GCP scope to scan. Accepts either a folder ID or an organization ID. When omitted, the scanner falls back to its default scope.
 - `space_id` (String) Mondoo space identifier. If there is no ID, the provider space is used.
 
 ### Read-Only
@@ -79,6 +79,7 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
 Optional:
 
 - `excluded_tags_filter` (Map of String) Exclude filter: projects whose tags match at least one of these key-value pairs are skipped, even if they match the include filter. A value of `*` matches any value for that tag key.
+- `scan_schedule_hours` (Number) How often (in hours) the deployed scanner runs a scan.
 - `tags_filter` (Map of String) Include filter: when not empty, only projects whose tags match at least one of these key-value pairs are scanned. A value of `*` matches any value for that tag key.
 
 ## Import

--- a/docs/resources/integration_gcp_serverless.md
+++ b/docs/resources/integration_gcp_serverless.md
@@ -80,7 +80,7 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
 Optional:
 
 - `excluded_tags_filter` (Map of String) Exclude filter: projects whose tags match at least one of these key-value pairs are skipped, even if they match the include filter. A value of `*` matches any value for that tag key.
-- `scan_schedule_hours` (Number) How often (in hours) the deployed scanner runs a scan.
+- `scan_schedule_hours` (Number) How often (in hours) the deployed scanner runs a scan. Must be between 1 and 23.
 - `tags_filter` (Map of String) Include filter: when not empty, only projects whose tags match at least one of these key-value pairs are scanned. A value of `*` matches any value for that tag key.
 
 ## Import

--- a/docs/resources/integration_gcp_serverless.md
+++ b/docs/resources/integration_gcp_serverless.md
@@ -67,6 +67,7 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
 - `scan_configuration` (Attributes) Scan options that control what the deployed scanner scans. (see [below for nested schema](#nestedatt--scan_configuration))
 - `scope` (String) The GCP scope to scan. Accepts either a folder ID or an organization ID. When omitted, the scanner falls back to its default scope.
 - `space_id` (String) Mondoo space identifier. If there is no ID, the provider space is used.
+- `supplied_sa_identity` (String) A customer-provided service account identity to run this integration with, instead of the platform automatically creating one (bring-your-own-identity). Stored and returned verbatim.
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.15.0
 	github.com/stretchr/testify v1.11.1
-	go.mondoo.com/mondoo-go v0.0.0-20260709002749-cac3416689be
+	go.mondoo.com/mondoo-go v0.0.0-20260709150758-442350eb1fcc
 	go.mondoo.com/mql/v13 v13.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.15.0
 	github.com/stretchr/testify v1.11.1
-	go.mondoo.com/mondoo-go v0.0.0-20260629203915-296e0cbfca9f
+	go.mondoo.com/mondoo-go v0.0.0-20260709002749-cac3416689be
 	go.mondoo.com/mql/v13 v13.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ go.abhg.dev/goldmark/frontmatter v0.2.0/go.mod h1:XqrEkZuM57djk7zrlRUB02x8I5J0px
 go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=
 go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
-go.mondoo.com/mondoo-go v0.0.0-20260709002749-cac3416689be h1:dlBEIGrbUFjjZascGGnUrG2pCq9BfrXNQoEGTqk5Vqc=
-go.mondoo.com/mondoo-go v0.0.0-20260709002749-cac3416689be/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
+go.mondoo.com/mondoo-go v0.0.0-20260709150758-442350eb1fcc h1:QDRa38iqfJ46MVaGHYcXLlbACo9W0MfWka6YQncuaHg=
+go.mondoo.com/mondoo-go v0.0.0-20260709150758-442350eb1fcc/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
 go.mondoo.com/mql/v13 v13.5.1 h1:WpXdy7h6y28npvUYg2YaLa++8CbVjCGQoDiL+IwXbc8=
 go.mondoo.com/mql/v13 v13.5.1/go.mod h1:fZ2CbY2dmjBBiLIKJDuW9HqEGFfzsR/n0kxIRRw6zik=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=

--- a/go.sum
+++ b/go.sum
@@ -559,8 +559,8 @@ go.abhg.dev/goldmark/frontmatter v0.2.0/go.mod h1:XqrEkZuM57djk7zrlRUB02x8I5J0px
 go.etcd.io/etcd/api/v3 v3.5.4/go.mod h1:5GB2vv4A4AOn3yk7MftYGHkUfGtDHnEraIjym4dYz5A=
 go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3YSwc9/Ac1g=
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
-go.mondoo.com/mondoo-go v0.0.0-20260629203915-296e0cbfca9f h1:YXTeTSkT0Ycu68NNmX0YYdD2gjZVKlspc6oQNjjeD4c=
-go.mondoo.com/mondoo-go v0.0.0-20260629203915-296e0cbfca9f/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
+go.mondoo.com/mondoo-go v0.0.0-20260709002749-cac3416689be h1:dlBEIGrbUFjjZascGGnUrG2pCq9BfrXNQoEGTqk5Vqc=
+go.mondoo.com/mondoo-go v0.0.0-20260709002749-cac3416689be/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
 go.mondoo.com/mql/v13 v13.5.1 h1:WpXdy7h6y28npvUYg2YaLa++8CbVjCGQoDiL+IwXbc8=
 go.mondoo.com/mql/v13 v13.5.1/go.mod h1:fZ2CbY2dmjBBiLIKJDuW9HqEGFfzsR/n0kxIRRw6zik=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=

--- a/internal/provider/export_s3_bucket.go
+++ b/internal/provider/export_s3_bucket.go
@@ -207,8 +207,8 @@ func (r *S3BucketExportResource) Create(ctx context.Context, req resource.Create
 			Output:          outputFormat,
 			Bucket:          mondoov1.String(data.Bucket.ValueString()),
 			Region:          mondoov1.String(data.Region.ValueString()),
-			AccessKey:       mondoov1.String(data.Credentials.Key.AccessKey.ValueString()),
-			SecretAccessKey: mondoov1.String(data.Credentials.Key.SecretKey.ValueString()),
+			AccessKey:       mondoov1.NewStringPtr(mondoov1.String(data.Credentials.Key.AccessKey.ValueString())),
+			SecretAccessKey: mondoov1.NewStringPtr(mondoov1.String(data.Credentials.Key.SecretKey.ValueString())),
 		},
 	}
 
@@ -311,8 +311,8 @@ func (r *S3BucketExportResource) Update(ctx context.Context, req resource.Update
 				Output:          outputFormat,
 				Bucket:          mondoov1.String(data.Bucket.ValueString()),
 				Region:          mondoov1.String(data.Region.ValueString()),
-				AccessKey:       mondoov1.String(data.Credentials.Key.AccessKey.ValueString()),
-				SecretAccessKey: mondoov1.String(data.Credentials.Key.SecretKey.ValueString()),
+				AccessKey:       mondoov1.NewStringPtr(mondoov1.String(data.Credentials.Key.AccessKey.ValueString())),
+				SecretAccessKey: mondoov1.NewStringPtr(mondoov1.String(data.Credentials.Key.SecretKey.ValueString())),
 			},
 		})
 

--- a/internal/provider/integration_gcp_serverless_resource.go
+++ b/internal/provider/integration_gcp_serverless_resource.go
@@ -48,6 +48,9 @@ type integrationGcpServerlessResourceModel struct {
 	HostProjectID types.String `tfsdk:"host_project_id"`
 	// The GCP region where the serverless scanner is deployed.
 	Region types.String `tfsdk:"region"`
+	// (Optional.) A customer-provided service account identity to run the
+	// integration with, instead of the platform creating one.
+	SuppliedSaIdentity types.String `tfsdk:"supplied_sa_identity"`
 
 	// (Optional.)
 	ScanConfiguration *GcpServerlessScanConfigurationInput `tfsdk:"scan_configuration"`
@@ -92,6 +95,11 @@ func (m integrationGcpServerlessResourceModel) GetConfigurationOptions() *mondoo
 	// Omitted scope means the scanner falls back to its default scope.
 	if scope := m.Scope.ValueString(); scope != "" {
 		opts.Scope = mondoov1.NewStringPtr(mondoov1.String(scope))
+	}
+
+	// Omitted means the platform creates the integration's identity itself.
+	if sa := m.SuppliedSaIdentity.ValueString(); sa != "" {
+		opts.SuppliedSaIdentity = mondoov1.NewStringPtr(mondoov1.String(sa))
 	}
 
 	if m.ScanConfiguration != nil {
@@ -153,6 +161,10 @@ func (r *integrationGcpServerlessResource) Schema(ctx context.Context, req resou
 			"region": schema.StringAttribute{
 				MarkdownDescription: "The GCP region where the serverless scanner is deployed.",
 				Required:            true,
+			},
+			"supplied_sa_identity": schema.StringAttribute{
+				MarkdownDescription: "A customer-provided service account identity to run this integration with, instead of the platform automatically creating one (bring-your-own-identity). Stored and returned verbatim.",
+				Optional:            true,
 			},
 			"scan_configuration": schema.SingleNestedAttribute{
 				MarkdownDescription: "Scan options that control what the deployed scanner scans.",

--- a/internal/provider/integration_gcp_serverless_resource.go
+++ b/internal/provider/integration_gcp_serverless_resource.go
@@ -181,10 +181,10 @@ func (r *integrationGcpServerlessResource) Schema(ctx context.Context, req resou
 						ElementType:         types.StringType,
 					},
 					"scan_schedule_hours": schema.Int32Attribute{
-						MarkdownDescription: "How often (in hours) the deployed scanner runs a scan.",
+						MarkdownDescription: "How often (in hours) the deployed scanner runs a scan. Must be between 1 and 23.",
 						Optional:            true,
 						Validators: []validator.Int32{
-							int32validator.AtLeast(1),
+							int32validator.Between(1, 23),
 						},
 					},
 				},

--- a/internal/provider/integration_gcp_serverless_resource.go
+++ b/internal/provider/integration_gcp_serverless_resource.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	mondoov1 "go.mondoo.com/mondoo-go"
@@ -58,6 +60,8 @@ type GcpServerlessScanConfigurationInput struct {
 	// (Optional.) Exclude filter: projects whose tags match at least one of these
 	// key-value pairs are skipped. A value of "*" matches any value for the key.
 	ExcludedTagsFilter types.Map `tfsdk:"excluded_tags_filter"`
+	// (Optional.) How often (in hours) the deployed scanner runs a scan.
+	ScanScheduleHours types.Int32 `tfsdk:"scan_schedule_hours"`
 }
 
 // tagsFilterToKeyValueList converts a Terraform string map into the GraphQL
@@ -81,15 +85,22 @@ func tagsFilterToKeyValueList(m types.Map) *[]mondoov1.KeyValueInput {
 
 func (m integrationGcpServerlessResourceModel) GetConfigurationOptions() *mondoov1.GcpServerlessConfigurationOptionsInput {
 	opts := &mondoov1.GcpServerlessConfigurationOptionsInput{
-		Scope:         mondoov1.String(m.Scope.ValueString()),
 		HostProjectId: mondoov1.String(m.HostProjectID.ValueString()),
 		Region:        mondoov1.String(m.Region.ValueString()),
+	}
+
+	// Omitted scope means the scanner falls back to its default scope.
+	if scope := m.Scope.ValueString(); scope != "" {
+		opts.Scope = mondoov1.NewStringPtr(mondoov1.String(scope))
 	}
 
 	if m.ScanConfiguration != nil {
 		opts.ScanConfiguration = &mondoov1.GcpServerlessScanConfigurationInput{
 			TagsFilter:         tagsFilterToKeyValueList(m.ScanConfiguration.TagsFilter),
 			ExcludedTagsFilter: tagsFilterToKeyValueList(m.ScanConfiguration.ExcludedTagsFilter),
+		}
+		if !m.ScanConfiguration.ScanScheduleHours.IsNull() && !m.ScanConfiguration.ScanScheduleHours.IsUnknown() {
+			opts.ScanConfiguration.ScanScheduleHours = mondoov1.NewIntPtr(mondoov1.Int(m.ScanConfiguration.ScanScheduleHours.ValueInt32()))
 		}
 	}
 
@@ -132,8 +143,8 @@ func (r *integrationGcpServerlessResource) Schema(ctx context.Context, req resou
 				Required:            true,
 			},
 			"scope": schema.StringAttribute{
-				MarkdownDescription: "The GCP scope to scan. Accepts either a folder ID or an organization ID.",
-				Required:            true,
+				MarkdownDescription: "The GCP scope to scan. Accepts either a folder ID or an organization ID. When omitted, the scanner falls back to its default scope.",
+				Optional:            true,
 			},
 			"host_project_id": schema.StringAttribute{
 				MarkdownDescription: "The GCP project ID where the serverless scanner is deployed.",
@@ -156,6 +167,13 @@ func (r *integrationGcpServerlessResource) Schema(ctx context.Context, req resou
 						MarkdownDescription: "Exclude filter: projects whose tags match at least one of these key-value pairs are skipped, even if they match the include filter. A value of `*` matches any value for that tag key.",
 						Optional:            true,
 						ElementType:         types.StringType,
+					},
+					"scan_schedule_hours": schema.Int32Attribute{
+						MarkdownDescription: "How often (in hours) the deployed scanner runs a scan.",
+						Optional:            true,
+						Validators: []validator.Int32{
+							int32validator.AtLeast(1),
+						},
 					},
 				},
 			},

--- a/internal/provider/integration_gcp_serverless_resource_test.go
+++ b/internal/provider/integration_gcp_serverless_resource_test.go
@@ -21,11 +21,57 @@ func TestIntegrationGcpServerlessGetConfigurationOptions_Minimal(t *testing.T) {
 
 	opts := m.GetConfigurationOptions()
 	require.NotNil(t, opts)
-	assert.EqualValues(t, "123456789012", opts.Scope)
+	require.NotNil(t, opts.Scope)
+	assert.EqualValues(t, "123456789012", *opts.Scope)
 	assert.EqualValues(t, "my-host-project", opts.HostProjectId)
 	assert.EqualValues(t, "us-central1", opts.Region)
+	// No supplied identity => the field is omitted from the request.
+	assert.Nil(t, opts.SuppliedSaIdentity)
 	// No scan_configuration block => no scan configuration sent.
 	assert.Nil(t, opts.ScanConfiguration)
+}
+
+func TestIntegrationGcpServerlessGetConfigurationOptions_OmittedScope(t *testing.T) {
+	m := integrationGcpServerlessResourceModel{
+		HostProjectID: types.StringValue("my-host-project"),
+		Region:        types.StringValue("us-central1"),
+	}
+
+	opts := m.GetConfigurationOptions()
+	require.NotNil(t, opts)
+	// Omitted scope is not sent; the scanner falls back to its default scope.
+	assert.Nil(t, opts.Scope)
+}
+
+func TestIntegrationGcpServerlessGetConfigurationOptions_SuppliedSaIdentity(t *testing.T) {
+	m := integrationGcpServerlessResourceModel{
+		HostProjectID:      types.StringValue("my-host-project"),
+		Region:             types.StringValue("us-central1"),
+		SuppliedSaIdentity: types.StringValue("byoi-sa@my-host-project.iam.gserviceaccount.com"),
+	}
+
+	opts := m.GetConfigurationOptions()
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.SuppliedSaIdentity)
+	assert.EqualValues(t, "byoi-sa@my-host-project.iam.gserviceaccount.com", *opts.SuppliedSaIdentity)
+}
+
+func TestIntegrationGcpServerlessGetConfigurationOptions_ScanScheduleHours(t *testing.T) {
+	m := integrationGcpServerlessResourceModel{
+		HostProjectID: types.StringValue("my-host-project"),
+		Region:        types.StringValue("us-central1"),
+		ScanConfiguration: &GcpServerlessScanConfigurationInput{
+			TagsFilter:         types.MapNull(types.StringType),
+			ExcludedTagsFilter: types.MapNull(types.StringType),
+			ScanScheduleHours:  types.Int32Value(12),
+		},
+	}
+
+	opts := m.GetConfigurationOptions()
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.ScanConfiguration)
+	require.NotNil(t, opts.ScanConfiguration.ScanScheduleHours)
+	assert.EqualValues(t, 12, *opts.ScanConfiguration.ScanScheduleHours)
 }
 
 func TestIntegrationGcpServerlessGetConfigurationOptions_TagsFilters(t *testing.T) {
@@ -80,4 +126,6 @@ func TestIntegrationGcpServerlessGetConfigurationOptions_EmptyTagsFilterOmitted(
 	require.NotNil(t, opts.ScanConfiguration)
 	assert.Nil(t, opts.ScanConfiguration.TagsFilter)
 	assert.Nil(t, opts.ScanConfiguration.ExcludedTagsFilter)
+	// No schedule set => the field is omitted from the request.
+	assert.Nil(t, opts.ScanConfiguration.ScanScheduleHours)
 }


### PR DESCRIPTION
## What

Compared `mondoo_integration_gcp_serverless` against the server's current `GcpServerlessConfigurationOptionsInput` / `GcpServerlessScanConfigurationInput` GraphQL types and synced the gaps:

- **`scan_configuration.scan_schedule_hours`** (new, optional): how often, in hours, the deployed scanner runs a scan. Validated ≥ 1; omitted when unset.
- **`supplied_sa_identity`** (new, optional): a customer-provided service account identity to run the integration with, instead of the platform automatically creating one (bring-your-own-identity). Stored and returned verbatim; omitted when unset.
- **`scope` is now optional**, matching the API — when omitted, the scanner falls back to its default scope. An empty/omitted scope is no longer sent in the request (the SDK field is now a pointer).

Carrier change: bumps `mondoo-go` to the latest generated schema (`v0.0.0-20260709150758`). That bump also turns the S3 export's `accessKey`/`secretAccessKey` into pointer fields — call sites adapted, no behavior change.

## Not included

Server-side output-only fields (`orchestratorImage`, `gcsSource`, `currentModuleVersion`, `latestModuleVersion`) are not surfaced — the resource's `Read` doesn't refresh from the API today, so they'd be create-time-only snapshots; better done together with a real `Read` implementation if wanted.

## Notes

- `go build` / `go vet` / `make generate` (docs) pass; acceptance tests need a live org credential and weren't run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)