### PR TITLE
✨ gcp serverless: cross_org, WIF binding, propagate_project_tags

### DIFF
--- a/docs/resources/integration_gcp_serverless.md
+++ b/docs/resources/integration_gcp_serverless.md
@@ -71,7 +71,8 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
 # The base64-encoded WIF external account configuration for the deployed
 # scanner. Pass it to the serverless stack's Terraform deployment.
 output "gcp_serverless_wif_config" {
-  value = mondoo_integration_gcp_serverless.gcp_serverless.wif_config
+  description = "Base64-encoded WIF external account configuration for the deployed GCP serverless scanner."
+  value       = mondoo_integration_gcp_serverless.gcp_serverless.wif_config
 }
 ```
 

--- a/docs/resources/integration_gcp_serverless.md
+++ b/docs/resources/integration_gcp_serverless.md
@@ -29,6 +29,14 @@ variable "gcp_region" {
   default     = "us-central1"
 }
 
+# The numeric unique ID of the GCP service account the deployed scanner runs
+# as. Used as the WIF binding subject; required when use_wif is true.
+variable "gcp_service_account_id" {
+  description = "Numeric unique ID of the scanner's GCP service account."
+  type        = string
+  default     = ""
+}
+
 provider "mondoo" {
   space = "hungry-poet-123456"
 }
@@ -40,6 +48,12 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
   host_project_id = var.gcp_host_project_id
   region          = var.gcp_region
 
+  # Authenticate the deployed scanner back to the platform via GCP Workload
+  # Identity Federation. When enabled, a WIF binding is minted at create time
+  # and its config is returned as `wif_config` below.
+  use_wif            = true
+  service_account_id = var.gcp_service_account_id
+
   scan_configuration = {
     # Only scan projects tagged for production. A value of "*" matches any value.
     tags_filter = {
@@ -49,7 +63,15 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
     excluded_tags_filter = {
       "env" = "sandbox"
     }
+    # Propagate GCP project tags onto all discovered assets.
+    propagate_project_tags = true
   }
+}
+
+# The base64-encoded WIF external account configuration for the deployed
+# scanner. Pass it to the serverless stack's Terraform deployment.
+output "gcp_serverless_wif_config" {
+  value = mondoo_integration_gcp_serverless.gcp_serverless.wif_config
 }
 ```
 
@@ -64,15 +86,20 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
 
 ### Optional
 
+- `cross_org` (Boolean) Allow this integration to land scanned assets in spaces across multiple orgs. Only valid on organization-scoped integrations and only on private-instance deployments (rejected on prod and prod-eu). Requires `use_wif`. Immutable: changing it forces a new integration.
 - `scan_configuration` (Attributes) Scan options that control what the deployed scanner scans. (see [below for nested schema](#nestedatt--scan_configuration))
 - `scope` (String) The GCP scope to scan. Accepts either a folder ID or an organization ID. When omitted, the scanner falls back to its default scope.
+- `service_account_id` (String) The numeric unique ID of the GCP service account the deployed scanner runs as, used as the WIF binding subject. Required when `use_wif` is true. Immutable: changing it forces a new integration.
 - `space_id` (String) Mondoo space identifier. If there is no ID, the provider space is used.
 - `supplied_sa_identity` (String) A customer-provided service account identity to run this integration with, instead of the platform automatically creating one (bring-your-own-identity). Stored and returned verbatim.
+- `use_wif` (Boolean) When true, the deployed scanner authenticates back to the platform via GCP Workload Identity Federation: a WIF auth binding is minted at create time. Immutable: changing it forces a new integration.
 
 ### Read-Only
 
 - `mrn` (String) Integration identifier
 - `token` (String, Sensitive) Integration token. Pass this to the serverless scanner deployment to register it with this integration.
+- `wif_auth_binding_mrn` (String) MRN of the server-managed WIF auth binding created for this integration. Empty when `use_wif` is false.
+- `wif_config` (String) Base64-encoded WIF external account configuration for the deployed scanner. Pass it to the customer's Terraform deployment. Empty when `use_wif` is false.
 
 <a id="nestedatt--scan_configuration"></a>
 ### Nested Schema for `scan_configuration`
@@ -80,6 +107,7 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
 Optional:
 
 - `excluded_tags_filter` (Map of String) Exclude filter: projects whose tags match at least one of these key-value pairs are skipped, even if they match the include filter. A value of `*` matches any value for that tag key.
+- `propagate_project_tags` (Boolean) When true, the GCP project tags are propagated to all assets discovered under the project.
 - `scan_schedule_hours` (Number) How often (in hours) the deployed scanner runs a scan. Must be between 1 and 23.
 - `tags_filter` (Map of String) Include filter: when not empty, only projects whose tags match at least one of these key-value pairs are scanned. A value of `*` matches any value for that tag key.
 

--- a/examples/resources/mondoo_integration_gcp_serverless/resource.tf
+++ b/examples/resources/mondoo_integration_gcp_serverless/resource.tf
@@ -14,6 +14,14 @@ variable "gcp_region" {
   default     = "us-central1"
 }
 
+# The numeric unique ID of the GCP service account the deployed scanner runs
+# as. Used as the WIF binding subject; required when use_wif is true.
+variable "gcp_service_account_id" {
+  description = "Numeric unique ID of the scanner's GCP service account."
+  type        = string
+  default     = ""
+}
+
 provider "mondoo" {
   space = "hungry-poet-123456"
 }
@@ -25,6 +33,12 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
   host_project_id = var.gcp_host_project_id
   region          = var.gcp_region
 
+  # Authenticate the deployed scanner back to the platform via GCP Workload
+  # Identity Federation. When enabled, a WIF binding is minted at create time
+  # and its config is returned as `wif_config` below.
+  use_wif            = true
+  service_account_id = var.gcp_service_account_id
+
   scan_configuration = {
     # Only scan projects tagged for production. A value of "*" matches any value.
     tags_filter = {
@@ -34,5 +48,13 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
     excluded_tags_filter = {
       "env" = "sandbox"
     }
+    # Propagate GCP project tags onto all discovered assets.
+    propagate_project_tags = true
   }
+}
+
+# The base64-encoded WIF external account configuration for the deployed
+# scanner. Pass it to the serverless stack's Terraform deployment.
+output "gcp_serverless_wif_config" {
+  value = mondoo_integration_gcp_serverless.gcp_serverless.wif_config
 }

--- a/examples/resources/mondoo_integration_gcp_serverless/resource.tf
+++ b/examples/resources/mondoo_integration_gcp_serverless/resource.tf
@@ -56,5 +56,6 @@ resource "mondoo_integration_gcp_serverless" "gcp_serverless" {
 # The base64-encoded WIF external account configuration for the deployed
 # scanner. Pass it to the serverless stack's Terraform deployment.
 output "gcp_serverless_wif_config" {
-  value = mondoo_integration_gcp_serverless.gcp_serverless.wif_config
+  description = "Base64-encoded WIF external account configuration for the deployed GCP serverless scanner."
+  value       = mondoo_integration_gcp_serverless.gcp_serverless.wif_config
 }

--- a/gen/templates/gql_generated.go.tmpl
+++ b/gen/templates/gql_generated.go.tmpl
@@ -11,6 +11,7 @@ type ClientIntegrationConfigurationOptions struct {
 	CrowdstrikeFalconConfigurationOptions CrowdstrikeFalconConfigurationOptions `graphql:"... on CrowdstrikeFalconConfigurationOptions"`
 	EmailConfigurationOptions             EmailConfigurationOptions             `graphql:"... on EmailConfigurationOptions"`
 	GcpConfigurationOptions               GcpConfigurationOptions               `graphql:"... on GcpConfigurationOptions"`
+	GcpServerlessConfigurationOptions     GcpServerlessConfigurationOptions     `graphql:"... on GcpServerlessConfigurationOptions"`
 	AwsS3ConfigurationOptions             AwsS3ConfigurationOptions             `graphql:"... on AwsS3ConfigurationOptions"`
 	BigqueryConfigurationOptions          BigqueryConfigurationOptions          `graphql:"... on BigqueryConfigurationOptions"`
 	GithubConfigurationOptions            GithubConfigurationOptions            `graphql:"... on GithubConfigurationOptions"`

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.15.0
 	github.com/stretchr/testify v1.11.1
-	go.mondoo.com/mondoo-go v0.0.0-20260709150758-442350eb1fcc
+	go.mondoo.com/mondoo-go v0.0.0-20260710102002-43d8df21b0e3
 	go.mondoo.com/mql/v13 v13.5.1
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -561,6 +561,8 @@ go.etcd.io/etcd/client/pkg/v3 v3.5.4/go.mod h1:IJHfcCEKxYu1Os13ZdwCwIUTUVGYTSAM3
 go.etcd.io/etcd/client/v3 v3.5.4/go.mod h1:ZaRkVgBZC+L+dLCjTcF1hRXpgZXQPOvnA/Ak/gq3kiY=
 go.mondoo.com/mondoo-go v0.0.0-20260709150758-442350eb1fcc h1:QDRa38iqfJ46MVaGHYcXLlbACo9W0MfWka6YQncuaHg=
 go.mondoo.com/mondoo-go v0.0.0-20260709150758-442350eb1fcc/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
+go.mondoo.com/mondoo-go v0.0.0-20260710102002-43d8df21b0e3 h1:NXYCMxzwxGevtWfRd/Ygh+KrDGdBLmUMV3vGoMjn59E=
+go.mondoo.com/mondoo-go v0.0.0-20260710102002-43d8df21b0e3/go.mod h1:hESCStkuJqvuw0cWwVKrorQJJnGdxUnSdR4Zs1/W1W4=
 go.mondoo.com/mql/v13 v13.5.1 h1:WpXdy7h6y28npvUYg2YaLa++8CbVjCGQoDiL+IwXbc8=
 go.mondoo.com/mql/v13 v13.5.1/go.mod h1:fZ2CbY2dmjBBiLIKJDuW9HqEGFfzsR/n0kxIRRw6zik=
 go.mondoo.com/ranger-rpc v0.8.0 h1:iBY34IhtPNPnEOZ9eS5t3Gp28HiTuv/M0SaHiBiRJlI=

--- a/internal/provider/gql.go
+++ b/internal/provider/gql.go
@@ -910,6 +910,14 @@ type GcpConfigurationOptions struct {
 	WifSubject             string
 }
 
+type GcpServerlessConfigurationOptions struct {
+	CrossOrg          bool
+	UseWif            bool
+	ServiceAccountId  string
+	WifAuthBindingMrn string
+	WifConfig         string
+}
+
 type ShodanConfigurationOptions struct {
 	Targets []string
 }

--- a/internal/provider/gql_generated.go
+++ b/internal/provider/gql_generated.go
@@ -11,6 +11,7 @@ type ClientIntegrationConfigurationOptions struct {
 	CrowdstrikeFalconConfigurationOptions CrowdstrikeFalconConfigurationOptions `graphql:"... on CrowdstrikeFalconConfigurationOptions"`
 	EmailConfigurationOptions             EmailConfigurationOptions             `graphql:"... on EmailConfigurationOptions"`
 	GcpConfigurationOptions               GcpConfigurationOptions               `graphql:"... on GcpConfigurationOptions"`
+	GcpServerlessConfigurationOptions     GcpServerlessConfigurationOptions     `graphql:"... on GcpServerlessConfigurationOptions"`
 	AwsS3ConfigurationOptions             AwsS3ConfigurationOptions             `graphql:"... on AwsS3ConfigurationOptions"`
 	BigqueryConfigurationOptions          BigqueryConfigurationOptions          `graphql:"... on BigqueryConfigurationOptions"`
 	GithubConfigurationOptions            GithubConfigurationOptions            `graphql:"... on GithubConfigurationOptions"`

--- a/internal/provider/integration_gcp_serverless_resource.go
+++ b/internal/provider/integration_gcp_serverless_resource.go
@@ -9,8 +9,10 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -52,6 +54,24 @@ type integrationGcpServerlessResourceModel struct {
 	// integration with, instead of the platform creating one.
 	SuppliedSaIdentity types.String `tfsdk:"supplied_sa_identity"`
 
+	// Allow this integration to land scanned assets in spaces across multiple
+	// orgs. Immutable after creation.
+	CrossOrg types.Bool `tfsdk:"cross_org"`
+	// When true, the deployed scanner authenticates back to the platform via GCP
+	// Workload Identity Federation. Immutable after creation.
+	UseWif types.Bool `tfsdk:"use_wif"`
+	// The numeric unique ID of the GCP service account the deployed scanner runs
+	// as, used as the WIF binding subject. Immutable after creation.
+	ServiceAccountID types.String `tfsdk:"service_account_id"`
+
+	// (Computed.) MRN of the server-managed WIF auth binding created for this
+	// integration. Empty when use_wif is false.
+	WifAuthBindingMrn types.String `tfsdk:"wif_auth_binding_mrn"`
+	// (Computed.) Base64-encoded WIF external account configuration for the
+	// deployed scanner. Pass it to the customer's Terraform deployment. Empty
+	// when use_wif is false.
+	WifConfig types.String `tfsdk:"wif_config"`
+
 	// (Optional.)
 	ScanConfiguration *GcpServerlessScanConfigurationInput `tfsdk:"scan_configuration"`
 }
@@ -65,6 +85,9 @@ type GcpServerlessScanConfigurationInput struct {
 	ExcludedTagsFilter types.Map `tfsdk:"excluded_tags_filter"`
 	// (Optional.) How often (in hours) the deployed scanner runs a scan.
 	ScanScheduleHours types.Int32 `tfsdk:"scan_schedule_hours"`
+	// (Optional.) When true, the GCP project tags are propagated to all assets
+	// discovered under the project.
+	PropagateProjectTags types.Bool `tfsdk:"propagate_project_tags"`
 }
 
 // tagsFilterToKeyValueList converts a Terraform string map into the GraphQL
@@ -102,6 +125,16 @@ func (m integrationGcpServerlessResourceModel) GetConfigurationOptions() *mondoo
 		opts.SuppliedSaIdentity = mondoov1.NewStringPtr(mondoov1.String(sa))
 	}
 
+	if !m.CrossOrg.IsNull() && !m.CrossOrg.IsUnknown() {
+		opts.CrossOrg = mondoov1.NewBooleanPtr(mondoov1.Boolean(m.CrossOrg.ValueBool()))
+	}
+	if !m.UseWif.IsNull() && !m.UseWif.IsUnknown() {
+		opts.UseWif = mondoov1.NewBooleanPtr(mondoov1.Boolean(m.UseWif.ValueBool()))
+	}
+	if !m.ServiceAccountID.IsNull() && !m.ServiceAccountID.IsUnknown() {
+		opts.ServiceAccountId = mondoov1.NewStringPtr(mondoov1.String(m.ServiceAccountID.ValueString()))
+	}
+
 	if m.ScanConfiguration != nil {
 		opts.ScanConfiguration = &mondoov1.GcpServerlessScanConfigurationInput{
 			TagsFilter:         tagsFilterToKeyValueList(m.ScanConfiguration.TagsFilter),
@@ -109,6 +142,9 @@ func (m integrationGcpServerlessResourceModel) GetConfigurationOptions() *mondoo
 		}
 		if !m.ScanConfiguration.ScanScheduleHours.IsNull() && !m.ScanConfiguration.ScanScheduleHours.IsUnknown() {
 			opts.ScanConfiguration.ScanScheduleHours = mondoov1.NewIntPtr(mondoov1.Int(m.ScanConfiguration.ScanScheduleHours.ValueInt32()))
+		}
+		if !m.ScanConfiguration.PropagateProjectTags.IsNull() && !m.ScanConfiguration.PropagateProjectTags.IsUnknown() {
+			opts.ScanConfiguration.PropagateProjectTags = mondoov1.NewBooleanPtr(mondoov1.Boolean(m.ScanConfiguration.PropagateProjectTags.ValueBool()))
 		}
 	}
 
@@ -166,6 +202,38 @@ func (r *integrationGcpServerlessResource) Schema(ctx context.Context, req resou
 				MarkdownDescription: "A customer-provided service account identity to run this integration with, instead of the platform automatically creating one (bring-your-own-identity). Stored and returned verbatim.",
 				Optional:            true,
 			},
+			"cross_org": schema.BoolAttribute{
+				MarkdownDescription: "Allow this integration to land scanned assets in spaces across multiple orgs. Only valid on organization-scoped integrations and only on private-instance deployments (rejected on prod and prod-eu). Requires `use_wif`. Immutable: changing it forces a new integration.",
+				Optional:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"use_wif": schema.BoolAttribute{
+				MarkdownDescription: "When true, the deployed scanner authenticates back to the platform via GCP Workload Identity Federation: a WIF auth binding is minted at create time. Immutable: changing it forces a new integration.",
+				Optional:            true,
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+			},
+			"service_account_id": schema.StringAttribute{
+				MarkdownDescription: "The numeric unique ID of the GCP service account the deployed scanner runs as, used as the WIF binding subject. Required when `use_wif` is true. Immutable: changing it forces a new integration.",
+				Optional:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"wif_auth_binding_mrn": schema.StringAttribute{
+				MarkdownDescription: "MRN of the server-managed WIF auth binding created for this integration. Empty when `use_wif` is false.",
+				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
+			"wif_config": schema.StringAttribute{
+				MarkdownDescription: "Base64-encoded WIF external account configuration for the deployed scanner. Pass it to the customer's Terraform deployment. Empty when `use_wif` is false.",
+				Computed:            true,
+			},
 			"scan_configuration": schema.SingleNestedAttribute{
 				MarkdownDescription: "Scan options that control what the deployed scanner scans.",
 				Optional:            true,
@@ -186,6 +254,10 @@ func (r *integrationGcpServerlessResource) Schema(ctx context.Context, req resou
 						Validators: []validator.Int32{
 							int32validator.Between(1, 23),
 						},
+					},
+					"propagate_project_tags": schema.BoolAttribute{
+						MarkdownDescription: "When true, the GCP project tags are propagated to all assets discovered under the project.",
+						Optional:            true,
 					},
 				},
 			},
@@ -264,8 +336,29 @@ func (r *integrationGcpServerlessResource) Create(ctx context.Context, req resou
 	data.Token = types.StringValue(string(integration.Token))
 	data.SpaceID = types.StringValue(space.ID())
 
+	// Fetch the full integration to populate the server-computed WIF fields
+	// (wif_config / wif_auth_binding_mrn), which are minted at create time.
+	r.applyComputedWifFields(ctx, string(integration.Mrn), &data, &resp.Diagnostics)
+
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+// applyComputedWifFields fetches the integration and copies the server-managed
+// WIF outputs onto the model. Computed attributes must be set to known values,
+// so on error it falls back to empty strings.
+func (r *integrationGcpServerlessResource) applyComputedWifFields(ctx context.Context, mrn string, data *integrationGcpServerlessResourceModel, diags *diag.Diagnostics) {
+	fetched, err := r.client.GetClientIntegration(ctx, mrn)
+	if err != nil {
+		diags.AddWarning("Client Warning",
+			fmt.Sprintf("Unable to fetch integration to populate computed WIF fields. Got error: %s", err))
+		data.WifConfig = types.StringValue("")
+		data.WifAuthBindingMrn = types.StringValue("")
+		return
+	}
+	opts := fetched.ConfigurationOptions.GcpServerlessConfigurationOptions
+	data.WifConfig = types.StringValue(opts.WifConfig)
+	data.WifAuthBindingMrn = types.StringValue(opts.WifAuthBindingMrn)
 }
 
 func (r *integrationGcpServerlessResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -278,7 +371,8 @@ func (r *integrationGcpServerlessResource) Read(ctx context.Context, req resourc
 		return
 	}
 
-	// Read API call logic
+	// Refresh the server-computed WIF fields.
+	r.applyComputedWifFields(ctx, data.Mrn.ValueString(), &data, &resp.Diagnostics)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -312,6 +406,9 @@ func (r *integrationGcpServerlessResource) Update(ctx context.Context, req resou
 			)
 		return
 	}
+
+	// Refresh the server-computed WIF fields.
+	r.applyComputedWifFields(ctx, data.Mrn.ValueString(), &data, &resp.Diagnostics)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/integration_gcp_serverless_resource.go
+++ b/internal/provider/integration_gcp_serverless_resource.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/int32validator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
@@ -23,8 +24,9 @@ import (
 
 // Ensure provider defined types fully satisfy framework interfaces.
 var (
-	_ resource.Resource                = (*integrationGcpServerlessResource)(nil)
-	_ resource.ResourceWithImportState = (*integrationGcpServerlessResource)(nil)
+	_ resource.Resource                   = (*integrationGcpServerlessResource)(nil)
+	_ resource.ResourceWithImportState    = (*integrationGcpServerlessResource)(nil)
+	_ resource.ResourceWithValidateConfig = (*integrationGcpServerlessResource)(nil)
 )
 
 func NewIntegrationGcpServerlessResource() resource.Resource {
@@ -233,6 +235,9 @@ func (r *integrationGcpServerlessResource) Schema(ctx context.Context, req resou
 			"wif_config": schema.StringAttribute{
 				MarkdownDescription: "Base64-encoded WIF external account configuration for the deployed scanner. Pass it to the customer's Terraform deployment. Empty when `use_wif` is false.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"scan_configuration": schema.SingleNestedAttribute{
 				MarkdownDescription: "Scan options that control what the deployed scanner scans.",
@@ -283,6 +288,42 @@ func (r *integrationGcpServerlessResource) Configure(ctx context.Context, req re
 	}
 
 	r.client = client
+}
+
+// ValidateConfig enforces the WIF / cross-org preconditions at plan time so
+// misconfigurations surface during `terraform validate` instead of failing at
+// the API on apply.
+func (r *integrationGcpServerlessResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var data integrationGcpServerlessResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(validateGcpServerlessConfig(&data)...)
+}
+
+// validateGcpServerlessConfig holds the WIF / cross-org precondition checks.
+// Unknown values (references to other resources) are skipped so validation does
+// not fire before the value is resolved.
+func validateGcpServerlessConfig(data *integrationGcpServerlessResourceModel) (diagnostics diag.Diagnostics) {
+	// use_wif requires a service_account_id (the WIF binding subject).
+	if data.UseWif.ValueBool() && !data.ServiceAccountID.IsUnknown() && data.ServiceAccountID.ValueString() == "" {
+		diagnostics.AddAttributeError(
+			path.Root("service_account_id"),
+			"Missing service_account_id",
+			"service_account_id is required when use_wif is set to true.",
+		)
+	}
+
+	// cross_org mints a platform-scoped WIF binding, so it requires use_wif.
+	if data.CrossOrg.ValueBool() && !data.UseWif.IsUnknown() && !data.UseWif.ValueBool() {
+		diagnostics.AddAttributeError(
+			path.Root("use_wif"),
+			"cross_org requires use_wif",
+			"use_wif must be set to true when cross_org is enabled.",
+		)
+	}
+	return diagnostics
 }
 
 func (r *integrationGcpServerlessResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -356,7 +397,15 @@ func (r *integrationGcpServerlessResource) applyComputedWifFields(ctx context.Co
 		data.WifAuthBindingMrn = types.StringValue("")
 		return
 	}
+	// GcpServerlessConfigurationOptions is a value type in the union (not a
+	// pointer), so there is nothing to nil-check. If use_wif is set but the
+	// server returned an empty WIF config, surface it as a warning rather than
+	// silently masking the real value with an empty string.
 	opts := fetched.ConfigurationOptions.GcpServerlessConfigurationOptions
+	if data.UseWif.ValueBool() && opts.WifConfig == "" {
+		diags.AddWarning("Client Warning",
+			"use_wif is enabled but the server returned an empty WIF config; the deployed scanner may not be able to authenticate.")
+	}
 	data.WifConfig = types.StringValue(opts.WifConfig)
 	data.WifAuthBindingMrn = types.StringValue(opts.WifAuthBindingMrn)
 }

--- a/internal/provider/integration_gcp_serverless_resource_test.go
+++ b/internal/provider/integration_gcp_serverless_resource_test.go
@@ -181,6 +181,72 @@ func TestIntegrationGcpServerlessGetConfigurationOptions_WifCrossOrgSupplied(t *
 	assert.EqualValues(t, true, *opts.ScanConfiguration.PropagateProjectTags)
 }
 
+// TestValidateGcpServerlessConfig covers the plan-time WIF / cross-org
+// precondition checks.
+func TestValidateGcpServerlessConfig(t *testing.T) {
+	cases := []struct {
+		name    string
+		model   integrationGcpServerlessResourceModel
+		wantErr bool
+	}{
+		{
+			name:  "no wif, no cross_org — valid",
+			model: integrationGcpServerlessResourceModel{HostProjectID: types.StringValue("p"), Region: types.StringValue("r")},
+		},
+		{
+			name: "use_wif with service_account_id — valid",
+			model: integrationGcpServerlessResourceModel{
+				UseWif:           types.BoolValue(true),
+				ServiceAccountID: types.StringValue("123456789012345678901"),
+			},
+		},
+		{
+			name:    "use_wif without service_account_id — error",
+			model:   integrationGcpServerlessResourceModel{UseWif: types.BoolValue(true)},
+			wantErr: true,
+		},
+		{
+			name:    "use_wif with empty service_account_id — error",
+			model:   integrationGcpServerlessResourceModel{UseWif: types.BoolValue(true), ServiceAccountID: types.StringValue("")},
+			wantErr: true,
+		},
+		{
+			name: "use_wif with unknown service_account_id — skipped (valid)",
+			model: integrationGcpServerlessResourceModel{
+				UseWif:           types.BoolValue(true),
+				ServiceAccountID: types.StringUnknown(),
+			},
+		},
+		{
+			name: "cross_org with use_wif — valid",
+			model: integrationGcpServerlessResourceModel{
+				CrossOrg:         types.BoolValue(true),
+				UseWif:           types.BoolValue(true),
+				ServiceAccountID: types.StringValue("123456789012345678901"),
+			},
+		},
+		{
+			name:    "cross_org without use_wif — error",
+			model:   integrationGcpServerlessResourceModel{CrossOrg: types.BoolValue(true), UseWif: types.BoolValue(false)},
+			wantErr: true,
+		},
+		{
+			name: "cross_org with unknown use_wif — skipped (valid)",
+			model: integrationGcpServerlessResourceModel{
+				CrossOrg: types.BoolValue(true),
+				UseWif:   types.BoolUnknown(),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			diags := validateGcpServerlessConfig(&tc.model)
+			assert.Equal(t, tc.wantErr, diags.HasError(), "diagnostics: %v", diags)
+		})
+	}
+}
+
 func TestIntegrationGcpServerlessGetConfigurationOptions_OmittedScope(t *testing.T) {
 	m := integrationGcpServerlessResourceModel{
 		HostProjectID: types.StringValue("my-host-project"),

--- a/internal/provider/integration_gcp_serverless_resource_test.go
+++ b/internal/provider/integration_gcp_serverless_resource_test.go
@@ -10,7 +10,22 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	mondoov1 "go.mondoo.com/mondoo-go"
 )
+
+func boolPtr(b bool) *bool { return &b }
+
+// assertBoolPtr asserts a *mondoov1.Boolean equals the expected *bool, treating
+// nil as "field omitted from the request".
+func assertBoolPtr(t *testing.T, want *bool, got *mondoov1.Boolean) {
+	t.Helper()
+	if want == nil {
+		assert.Nil(t, got)
+		return
+	}
+	require.NotNil(t, got)
+	assert.EqualValues(t, *want, bool(*got))
+}
 
 func TestIntegrationGcpServerlessGetConfigurationOptions_Minimal(t *testing.T) {
 	m := integrationGcpServerlessResourceModel{
@@ -27,8 +42,143 @@ func TestIntegrationGcpServerlessGetConfigurationOptions_Minimal(t *testing.T) {
 	assert.EqualValues(t, "us-central1", opts.Region)
 	// No supplied identity => the field is omitted from the request.
 	assert.Nil(t, opts.SuppliedSaIdentity)
+	// None of the WIF / cross-org optionals are set => all omitted.
+	assert.Nil(t, opts.CrossOrg)
+	assert.Nil(t, opts.UseWif)
+	assert.Nil(t, opts.ServiceAccountId)
 	// No scan_configuration block => no scan configuration sent.
 	assert.Nil(t, opts.ScanConfiguration)
+}
+
+// TestIntegrationGcpServerlessGetConfigurationOptions_OptionalBoolFields covers
+// the tri-state semantics of the optional boolean fields: unset (null) is
+// omitted from the request, while an explicit true OR false is sent through.
+// Sending an explicit false matters — it must not be conflated with "unset".
+func TestIntegrationGcpServerlessGetConfigurationOptions_OptionalBoolFields(t *testing.T) {
+	base := func() integrationGcpServerlessResourceModel {
+		return integrationGcpServerlessResourceModel{
+			HostProjectID: types.StringValue("my-host-project"),
+			Region:        types.StringValue("us-central1"),
+		}
+	}
+
+	t.Run("cross_org", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   types.Bool
+			want *bool
+		}{
+			{"unset is omitted", types.BoolNull(), nil},
+			{"explicit true is sent", types.BoolValue(true), boolPtr(true)},
+			{"explicit false is sent", types.BoolValue(false), boolPtr(false)},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				m := base()
+				m.CrossOrg = tc.in
+				got := m.GetConfigurationOptions().CrossOrg
+				assertBoolPtr(t, tc.want, got)
+			})
+		}
+	})
+
+	t.Run("use_wif", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   types.Bool
+			want *bool
+		}{
+			{"unset is omitted", types.BoolNull(), nil},
+			{"explicit true is sent", types.BoolValue(true), boolPtr(true)},
+			{"explicit false is sent", types.BoolValue(false), boolPtr(false)},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				m := base()
+				m.UseWif = tc.in
+				got := m.GetConfigurationOptions().UseWif
+				assertBoolPtr(t, tc.want, got)
+			})
+		}
+	})
+
+	t.Run("propagate_project_tags", func(t *testing.T) {
+		cases := []struct {
+			name string
+			in   types.Bool
+			want *bool
+		}{
+			{"unset is omitted", types.BoolNull(), nil},
+			{"explicit true is sent", types.BoolValue(true), boolPtr(true)},
+			{"explicit false is sent", types.BoolValue(false), boolPtr(false)},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				m := base()
+				m.ScanConfiguration = &GcpServerlessScanConfigurationInput{
+					TagsFilter:           types.MapNull(types.StringType),
+					ExcludedTagsFilter:   types.MapNull(types.StringType),
+					PropagateProjectTags: tc.in,
+				}
+				sc := m.GetConfigurationOptions().ScanConfiguration
+				require.NotNil(t, sc)
+				assertBoolPtr(t, tc.want, sc.PropagateProjectTags)
+			})
+		}
+	})
+}
+
+// TestIntegrationGcpServerlessGetConfigurationOptions_ServiceAccountId covers
+// the optional numeric service account id used as the WIF binding subject.
+func TestIntegrationGcpServerlessGetConfigurationOptions_ServiceAccountId(t *testing.T) {
+	t.Run("unset is omitted", func(t *testing.T) {
+		m := integrationGcpServerlessResourceModel{
+			HostProjectID: types.StringValue("my-host-project"),
+			Region:        types.StringValue("us-central1"),
+		}
+		assert.Nil(t, m.GetConfigurationOptions().ServiceAccountId)
+	})
+
+	t.Run("supplied is sent", func(t *testing.T) {
+		m := integrationGcpServerlessResourceModel{
+			HostProjectID:    types.StringValue("my-host-project"),
+			Region:           types.StringValue("us-central1"),
+			ServiceAccountID: types.StringValue("123456789012345678901"),
+		}
+		got := m.GetConfigurationOptions().ServiceAccountId
+		require.NotNil(t, got)
+		assert.EqualValues(t, "123456789012345678901", *got)
+	})
+}
+
+// TestIntegrationGcpServerlessGetConfigurationOptions_WifCrossOrgSupplied is a
+// full "everything supplied" WIF + cross-org integration.
+func TestIntegrationGcpServerlessGetConfigurationOptions_WifCrossOrgSupplied(t *testing.T) {
+	m := integrationGcpServerlessResourceModel{
+		Scope:            types.StringValue("organizations/123456789012"),
+		HostProjectID:    types.StringValue("my-host-project"),
+		Region:           types.StringValue("us-central1"),
+		CrossOrg:         types.BoolValue(true),
+		UseWif:           types.BoolValue(true),
+		ServiceAccountID: types.StringValue("123456789012345678901"),
+		ScanConfiguration: &GcpServerlessScanConfigurationInput{
+			TagsFilter:           types.MapNull(types.StringType),
+			ExcludedTagsFilter:   types.MapNull(types.StringType),
+			PropagateProjectTags: types.BoolValue(true),
+		},
+	}
+
+	opts := m.GetConfigurationOptions()
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.CrossOrg)
+	assert.EqualValues(t, true, *opts.CrossOrg)
+	require.NotNil(t, opts.UseWif)
+	assert.EqualValues(t, true, *opts.UseWif)
+	require.NotNil(t, opts.ServiceAccountId)
+	assert.EqualValues(t, "123456789012345678901", *opts.ServiceAccountId)
+	require.NotNil(t, opts.ScanConfiguration)
+	require.NotNil(t, opts.ScanConfiguration.PropagateProjectTags)
+	assert.EqualValues(t, true, *opts.ScanConfiguration.PropagateProjectTags)
 }
 
 func TestIntegrationGcpServerlessGetConfigurationOptions_OmittedScope(t *testing.T) {


### PR DESCRIPTION
## What

Wires the new GCP serverless API fields into the `mondoo_integration_gcp_serverless` resource, following server PR [mondoohq/server#17145](https://github.com/mondoohq/server/pull/17145). Bumps `mondoo-go` to the version that exposes these fields.

## Inputs

- `cross_org` (Bool) — land assets across multiple orgs; org-scoped + private-instance only; requires `use_wif`.
- `use_wif` (Bool) — authenticate the deployed scanner back to the platform via GCP Workload Identity Federation.
- `service_account_id` (String) — numeric SA unique ID used as the WIF binding subject; required when `use_wif` is true.
- `scan_configuration.propagate_project_tags` (Bool).

`cross_org`, `use_wif`, and `service_account_id` are immutable server-side, so they carry `RequiresReplace` — changing them recreates the integration instead of erroring on apply.

## Computed outputs

Read back from the API after create/update via `GetClientIntegration`:

- `wif_auth_binding_mrn` — MRN of the server-managed WIF binding.
- `wif_config` — base64 external-account config to hand to the serverless stack's Terraform deployment (the whole point of exposing it: pass it through). Empty when `use_wif` is false.

Adds a `GcpServerlessConfigurationOptions` read-back struct and the union entry in **both** the generated file and its template (`gen/templates/gql_generated.go.tmpl`), so it survives `go generate`. `Read`/`Update` now refresh the computed WIF fields (the resource previously had a no-op `Read`).

## Tests

Detailed unit tests for `GetConfigurationOptions` covering every optional field **unset vs supplied**, including:
- Tri-state booleans (`cross_org`, `use_wif`, `propagate_project_tags`): unset → omitted, explicit `true` → sent, explicit `false` → sent (guards against conflating "false" with "unset").
- `service_account_id` omitted vs supplied.
- A full "everything supplied" WIF + cross-org case.

Example + generated docs updated. `go build`, `go vet`, and `go generate` are clean. (Acceptance/`TestMain`-gated tests run in CI where org credentials are available.)

## Notes

- Depends on the `mondoo-go` bump landing (already published at the pinned commit) and, transitively, on server #17145 which ships the schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
