### PR TITLE
🐛 azure: grant the legacy Run Command action so scan_vms works

### DIFF
--- a/docs/resources/integration_azure.md
+++ b/docs/resources/integration_azure.md
@@ -211,6 +211,12 @@ resource "azurerm_role_definition" "mondoo_security_role" {
       "Microsoft.KeyVault/locations/*/read",
       "Microsoft.KeyVault/vaults/*/read",
       "Microsoft.KeyVault/operations/read",
+      # scan_vms drives Mondoo's extended scanner, which calls the *legacy* Run
+      # Command endpoint (POST .../virtualMachines/{vm}/runCommand). That is a
+      # different resource type from the managed runCommands/* API below, with
+      # its own action — without it, VM scans fail with AuthorizationFailed on
+      # 'Microsoft.Compute/virtualMachines/runCommand/action'.
+      "Microsoft.Compute/virtualMachines/runCommand/action",
       "Microsoft.Compute/virtualMachines/runCommands/read",
       "Microsoft.Compute/virtualMachines/runCommands/write",
       "Microsoft.Compute/virtualMachines/runCommands/delete"
@@ -450,6 +456,12 @@ resource "azurerm_role_definition" "mondoo_security_role" {
       "Microsoft.KeyVault/locations/*/read",
       "Microsoft.KeyVault/vaults/*/read",
       "Microsoft.KeyVault/operations/read",
+      # scan_vms drives Mondoo's extended scanner, which calls the *legacy* Run
+      # Command endpoint (POST .../virtualMachines/{vm}/runCommand). That is a
+      # different resource type from the managed runCommands/* API below, with
+      # its own action — without it, VM scans fail with AuthorizationFailed on
+      # 'Microsoft.Compute/virtualMachines/runCommand/action'.
+      "Microsoft.Compute/virtualMachines/runCommand/action",
       "Microsoft.Compute/virtualMachines/runCommands/read",
       "Microsoft.Compute/virtualMachines/runCommands/write",
       "Microsoft.Compute/virtualMachines/runCommands/delete"

--- a/examples/resources/mondoo_integration_azure/resource.tf
+++ b/examples/resources/mondoo_integration_azure/resource.tf
@@ -196,6 +196,12 @@ resource "azurerm_role_definition" "mondoo_security_role" {
       "Microsoft.KeyVault/locations/*/read",
       "Microsoft.KeyVault/vaults/*/read",
       "Microsoft.KeyVault/operations/read",
+      # scan_vms drives Mondoo's extended scanner, which calls the *legacy* Run
+      # Command endpoint (POST .../virtualMachines/{vm}/runCommand). That is a
+      # different resource type from the managed runCommands/* API below, with
+      # its own action — without it, VM scans fail with AuthorizationFailed on
+      # 'Microsoft.Compute/virtualMachines/runCommand/action'.
+      "Microsoft.Compute/virtualMachines/runCommand/action",
       "Microsoft.Compute/virtualMachines/runCommands/read",
       "Microsoft.Compute/virtualMachines/runCommands/write",
       "Microsoft.Compute/virtualMachines/runCommands/delete"

--- a/examples/resources/mondoo_integration_azure/resource_wif.tf
+++ b/examples/resources/mondoo_integration_azure/resource_wif.tf
@@ -174,6 +174,12 @@ resource "azurerm_role_definition" "mondoo_security_role" {
       "Microsoft.KeyVault/locations/*/read",
       "Microsoft.KeyVault/vaults/*/read",
       "Microsoft.KeyVault/operations/read",
+      # scan_vms drives Mondoo's extended scanner, which calls the *legacy* Run
+      # Command endpoint (POST .../virtualMachines/{vm}/runCommand). That is a
+      # different resource type from the managed runCommands/* API below, with
+      # its own action — without it, VM scans fail with AuthorizationFailed on
+      # 'Microsoft.Compute/virtualMachines/runCommand/action'.
+      "Microsoft.Compute/virtualMachines/runCommand/action",
       "Microsoft.Compute/virtualMachines/runCommands/read",
       "Microsoft.Compute/virtualMachines/runCommands/write",
       "Microsoft.Compute/virtualMachines/runCommands/delete"


### PR DESCRIPTION
Both mondoo_integration_azure examples set `scan_vms = true`, but the custom role they define grants only the managed Run Command API:

    Microsoft.Compute/virtualMachines/runCommands/read|write|delete

Mondoo's extended scanner calls `VirtualMachinesClient.BeginRunCommand`, which hits the *legacy* endpoint `POST .../virtualMachines/{vm}/runCommand`. That is a separate resource type with its own action, so every VM scan fails:

    RESPONSE 403: AuthorizationFailed
    The client '<app-id>' with object id '<sp-oid>' does not have authorization
    to perform action 'Microsoft.Compute/virtualMachines/runCommand/action'
    over scope '.../virtualMachines/<vm>'

Adds `Microsoft.Compute/virtualMachines/runCommand/action` to both the client-secret (resource.tf) and WIF (resource_wif.tf) examples, with a comment explaining why the managed runCommands/* actions do not cover it. Docs regenerated with `make generate`.

Existing deployments pick this up on the next `terraform apply`, which updates the role definition in place — no new app registration or role assignment.

Deliberately not changed: the mondoo_integration_msdefender example carries the same runCommands/* trio, but the extended scanner only handles azure and github, so Defender never calls Run Command. Adding the action there would grant arbitrary command execution on VMs to an integration that cannot use it.