### PR TITLE
Add account_scan to mondoo_integration_aws_serverless

### DIFF
--- a/docs/resources/integration_aws_serverless.md
+++ b/docs/resources/integration_aws_serverless.md
@@ -120,6 +120,7 @@ Required:
 
 Optional:
 
+- `account_scan` (Boolean) Enable AWS account scan.
 - `cron_scan_in_hours` (Number) Cron scan in hours.
 - `ec2_scan` (Boolean) Enable EC2 scan.
 - `ecr_scan` (Boolean) Enable ECR scan.

--- a/docs/resources/integration_aws_serverless.md
+++ b/docs/resources/integration_aws_serverless.md
@@ -120,7 +120,7 @@ Required:
 
 Optional:
 
-- `account_scan` (Boolean) Enable AWS account scan.
+- `account_scan` (Boolean) Enable AWS account scan. Defaults to true when not set.
 - `cron_scan_in_hours` (Number) Cron scan in hours.
 - `ec2_scan` (Boolean) Enable EC2 scan.
 - `ecr_scan` (Boolean) Enable ECR scan.

--- a/internal/provider/integration_aws_serverless_resource.go
+++ b/internal/provider/integration_aws_serverless_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -60,6 +61,8 @@ type integrationAwsServerlessResourceModel struct {
 }
 
 type ScanConfigurationInput struct {
+	// (Optional.)
+	AccountScan types.Bool `tfsdk:"account_scan"`
 	// (Optional.)
 	Ec2Scan types.Bool `tfsdk:"ec2_scan"`
 	// (Optional.)
@@ -196,6 +199,7 @@ func (m integrationAwsServerlessResourceModel) GetConfigurationOptions() *mondoo
 		IsOrganization: mondoov1.NewBooleanPtr(mondoov1.Boolean(m.IsOrganization.ValueBool())),
 		AccountIDs:     &accountIDs,
 		ScanConfiguration: mondoov1.ScanConfigurationInput{
+			AccountScan:       mondoov1.NewBooleanPtr(mondoov1.Boolean(m.ScanConfiguration.AccountScan.ValueBool())),
 			Ec2Scan:           mondoov1.NewBooleanPtr(mondoov1.Boolean(m.ScanConfiguration.Ec2Scan.ValueBool())),
 			EcrScan:           mondoov1.NewBooleanPtr(mondoov1.Boolean(m.ScanConfiguration.EcrScan.ValueBool())),
 			EcsScan:           mondoov1.NewBooleanPtr(mondoov1.Boolean(m.ScanConfiguration.EcsScan.ValueBool())),
@@ -294,6 +298,12 @@ func (r *integrationAwsServerlessResource) Schema(ctx context.Context, req resou
 			"scan_configuration": schema.SingleNestedAttribute{
 				Required: true,
 				Attributes: map[string]schema.Attribute{
+					"account_scan": schema.BoolAttribute{
+						MarkdownDescription: "Enable AWS account scan.",
+						Optional:            true,
+						Computed:            true,
+						Default:             booldefault.StaticBool(true),
+					},
 					"ec2_scan": schema.BoolAttribute{
 						MarkdownDescription: "Enable EC2 scan.",
 						Optional:            true,

--- a/internal/provider/integration_aws_serverless_resource.go
+++ b/internal/provider/integration_aws_serverless_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -199,7 +198,6 @@ func (m integrationAwsServerlessResourceModel) GetConfigurationOptions() *mondoo
 		IsOrganization: mondoov1.NewBooleanPtr(mondoov1.Boolean(m.IsOrganization.ValueBool())),
 		AccountIDs:     &accountIDs,
 		ScanConfiguration: mondoov1.ScanConfigurationInput{
-			AccountScan:       mondoov1.NewBooleanPtr(mondoov1.Boolean(m.ScanConfiguration.AccountScan.ValueBool())),
 			Ec2Scan:           mondoov1.NewBooleanPtr(mondoov1.Boolean(m.ScanConfiguration.Ec2Scan.ValueBool())),
 			EcrScan:           mondoov1.NewBooleanPtr(mondoov1.Boolean(m.ScanConfiguration.EcrScan.ValueBool())),
 			EcsScan:           mondoov1.NewBooleanPtr(mondoov1.Boolean(m.ScanConfiguration.EcsScan.ValueBool())),
@@ -217,6 +215,14 @@ func (m integrationAwsServerlessResourceModel) GetConfigurationOptions() *mondoo
 				InstanceConnect:           mondoov1.NewBooleanPtr(mondoov1.Boolean(m.ScanConfiguration.Ec2ScanOptions.InstanceConnect.ValueBool())),
 			},
 		},
+	}
+
+	// account_scan is only sent when the practitioner set it. Leaving it off the
+	// request lets the API apply its own default of true; sending false for an
+	// unset attribute would silently disable account scanning for every
+	// configuration that predates this attribute.
+	if accountScan := m.ScanConfiguration.AccountScan; !accountScan.IsNull() && !accountScan.IsUnknown() {
+		opts.ScanConfiguration.AccountScan = mondoov1.NewBooleanPtr(mondoov1.Boolean(accountScan.ValueBool()))
 	}
 
 	if m.ScanConfiguration.VpcConfiguration != nil {
@@ -299,10 +305,8 @@ func (r *integrationAwsServerlessResource) Schema(ctx context.Context, req resou
 				Required: true,
 				Attributes: map[string]schema.Attribute{
 					"account_scan": schema.BoolAttribute{
-						MarkdownDescription: "Enable AWS account scan.",
+						MarkdownDescription: "Enable AWS account scan. Defaults to true when not set.",
 						Optional:            true,
-						Computed:            true,
-						Default:             booldefault.StaticBool(true),
 					},
 					"ec2_scan": schema.BoolAttribute{
 						MarkdownDescription: "Enable EC2 scan.",

--- a/internal/provider/integration_aws_serverless_resource_test.go
+++ b/internal/provider/integration_aws_serverless_resource_test.go
@@ -24,11 +24,23 @@ func TestIntegrationAwsServerlessResourceGetConfigurationOptions_AccountScan(t *
 		{name: "disabled", accountScan: types.BoolValue(false), expected: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			// Every list and map must be an explicitly typed null, the way
+			// Terraform decodes an unset attribute. A zero-value types.List has
+			// no element type, and GetConfigurationOptions calls ElementsAs on
+			// it, which dereferences that nil type and panics.
 			m := integrationAwsServerlessResourceModel{
-				Region: types.StringValue("us-east-1"),
+				Region:     types.StringValue("us-east-1"),
+				AccountIDs: types.ListNull(types.StringType),
 				ScanConfiguration: ScanConfigurationInput{
-					AccountScan:    tc.accountScan,
-					Ec2ScanOptions: &Ec2ScanOptionsInput{},
+					AccountScan: tc.accountScan,
+					Ec2ScanOptions: &Ec2ScanOptionsInput{
+						InstanceIdsFilter:        types.ListNull(types.StringType),
+						RegionsFilter:            types.ListNull(types.StringType),
+						TagsFilter:               types.MapNull(types.StringType),
+						ExcludeInstanceIdsFilter: types.ListNull(types.StringType),
+						ExcludeRegionsFilter:     types.ListNull(types.StringType),
+						ExcludeTagsFilter:        types.MapNull(types.StringType),
+					},
 				},
 			}
 

--- a/internal/provider/integration_aws_serverless_resource_test.go
+++ b/internal/provider/integration_aws_serverless_resource_test.go
@@ -8,7 +8,37 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/stretchr/testify/assert"
+	mondoov1 "go.mondoo.com/mondoo-go"
 )
+
+func TestIntegrationAwsServerlessResourceGetConfigurationOptions_AccountScan(t *testing.T) {
+	// account_scan carries a schema default of true, so the plan always resolves
+	// it to a known value before GetConfigurationOptions runs. Both settings must
+	// reach the API unchanged.
+	for _, tc := range []struct {
+		name        string
+		accountScan types.Bool
+		expected    bool
+	}{
+		{name: "enabled", accountScan: types.BoolValue(true), expected: true},
+		{name: "disabled", accountScan: types.BoolValue(false), expected: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := integrationAwsServerlessResourceModel{
+				Region: types.StringValue("us-east-1"),
+				ScanConfiguration: ScanConfigurationInput{
+					AccountScan:    tc.accountScan,
+					Ec2ScanOptions: &Ec2ScanOptionsInput{},
+				},
+			}
+
+			opts := m.GetConfigurationOptions()
+			if assert.NotNil(t, opts.ScanConfiguration.AccountScan) {
+				assert.Equal(t, mondoov1.Boolean(tc.expected), *opts.ScanConfiguration.AccountScan)
+			}
+		})
+	}
+}
 
 func TestIntegrationAwsServerlessResourceValidateConfig_Empty(t *testing.T) {
 	d := &integrationAwsServerlessResourceModel{}

--- a/internal/provider/integration_aws_serverless_resource_test.go
+++ b/internal/provider/integration_aws_serverless_resource_test.go
@@ -12,16 +12,20 @@ import (
 )
 
 func TestIntegrationAwsServerlessResourceGetConfigurationOptions_AccountScan(t *testing.T) {
-	// account_scan carries a schema default of true, so the plan always resolves
-	// it to a known value before GetConfigurationOptions runs. Both settings must
-	// reach the API unchanged.
+	// An explicit setting reaches the API unchanged. An unset attribute must be
+	// omitted from the request entirely so the API applies its own default of
+	// true — sending false there would disable account scanning for every
+	// configuration written before this attribute existed.
 	for _, tc := range []struct {
 		name        string
 		accountScan types.Bool
+		expectSent  bool
 		expected    bool
 	}{
-		{name: "enabled", accountScan: types.BoolValue(true), expected: true},
-		{name: "disabled", accountScan: types.BoolValue(false), expected: false},
+		{name: "enabled", accountScan: types.BoolValue(true), expectSent: true, expected: true},
+		{name: "disabled", accountScan: types.BoolValue(false), expectSent: true, expected: false},
+		{name: "unset", accountScan: types.BoolNull(), expectSent: false},
+		{name: "unknown", accountScan: types.BoolUnknown(), expectSent: false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Every list and map must be an explicitly typed null, the way
@@ -45,6 +49,10 @@ func TestIntegrationAwsServerlessResourceGetConfigurationOptions_AccountScan(t *
 			}
 
 			opts := m.GetConfigurationOptions()
+			if !tc.expectSent {
+				assert.Nil(t, opts.ScanConfiguration.AccountScan)
+				return
+			}
 			if assert.NotNil(t, opts.ScanConfiguration.AccountScan) {
 				assert.Equal(t, mondoov1.Boolean(tc.expected), *opts.ScanConfiguration.AccountScan)
 			}


### PR DESCRIPTION
## What

The `scan_configuration` block had no way to control AWS account scanning. The provider never sent `accountScan`, so every managed integration relied on the server's implicit default.

Adds an `account_scan` attribute to `scan_configuration`, wired into `GetConfigurationOptions` so it reaches the API on both create and update.

## Unset means unsent

`account_scan` is plain `Optional` — no `Computed`, no schema default — and is only put on the request when the practitioner actually set it. An unset attribute is omitted from the API call and the server applies its own default of `true`.

This is deliberate. `Optional + Computed + Default(true)` would have been the more explicit-looking option, but it makes every existing configuration that never set `account_scan` plan a `null -> true` change on the first plan after upgrading, calling `UpdateIntegration` for a value the API already stores. Adding a defaulted attribute to a resource people already hold in state is not the same as shipping one from day one (which is why the `http`/`https` defaults on `mondoo_integration_domain` are fine).

Consequence: upgrading is a no-op for anyone who does not opt in — no diff, no API call. The trade-off is that `terraform show` reports `account_scan = null` rather than the effective `true`, and the "unset means true" rule now lives in a guard in `GetConfigurationOptions` rather than in the schema. That guard is commented and pinned by a test, because dropping it would send `false` for unset and silently disable account scanning for every pre-existing configuration.

## Backwards compatibility

- No `RequiresReplace` anywhere in the resource, so no integration gets recreated.
- No `SchemaVersion`/state upgrader needed — adding an optional attribute is handled natively; prior state missing the key decodes as null.
- Nothing renamed, removed, retyped, or made required. Existing configurations stay valid as written.

## Dependency

Requires mondoohq/server#18541, which makes the server honor `accountScan` on input instead of hardcoding it to `true`. Merge order does not matter, but **deploy the server first**: until it ships, `account_scan = false` is accepted and written to state while the server still forces `true`, so state would claim account scanning is off when it isn't.

## Notes

- `mondoo-go` needed no change: `ScanConfigurationInput.AccountScan *Boolean` already exists in the pinned version.
- Docs regenerated with tfplugindocs.
- I could not run `./internal/provider` tests locally — `TestMain` provisions a real Mondoo space and requires org service-account credentials. `go vet ./internal/provider/` passes; CI does the real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)